### PR TITLE
Harden trading contract upgrade safety and governance controls

### DIFF
--- a/Contracts/contracts/trading/src/test.rs
+++ b/Contracts/contracts/trading/src/test.rs
@@ -222,7 +222,6 @@ fn test_pause_unpause_authorization() {
 }
 
 #[test]
-#[ignore = "Governance module uses legacy storage - needs migration"]
 fn test_upgrade_proposal_flow_and_errors() {
     let _guard = (); // serial_lock disabled
     let (env, admin, approver, executor, contract_id) = setup_env();
@@ -277,7 +276,6 @@ fn test_upgrade_proposal_flow_and_errors() {
 }
 
 #[test]
-#[ignore = "Governance module uses legacy storage - needs migration"]
 fn test_reject_and_get_proposal_errors() {
     let _guard = (); // serial_lock disabled
     let (env, admin, approver, executor, contract_id) = setup_env();
@@ -301,6 +299,52 @@ fn test_reject_and_get_proposal_errors() {
 
     let missing = client.try_get_upgrade_proposal(&999);
     assert_eq!(missing, Err(Ok(TradeError::Unauthorized)));
+}
+
+#[test]
+fn test_upgrade_governance_pause_and_timelock_validation() {
+    let _guard = ();
+    let (env, admin, approver, executor, contract_id) = setup_env();
+    let client = UpgradeableTradingContractClient::new(&env, &contract_id);
+    let mut approvers = Vec::new(&env);
+    approvers.push_back(approver.clone());
+    init_contract(&client, &admin, approvers.clone(), &executor);
+
+    let invalid_timelock = client.try_propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1,
+        &3599,
+    );
+    assert_eq!(invalid_timelock, Err(Ok(TradeError::Unauthorized)));
+
+    client.pause_upgrade_governance(&admin);
+
+    let paused_proposal = client.try_propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1,
+        &3600,
+    );
+    assert_eq!(paused_proposal, Err(Ok(TradeError::Unauthorized)));
+
+    client.resume_upgrade_governance(&admin);
+
+    let proposal_id = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1,
+        &3600,
+    );
+
+    let proposal = client.get_upgrade_proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR strengthens upgrade safety for the trading contract by tightening governance checks, adding an emergency halt for upgrades, and expanding tests that simulate realistic upgrade flows.

## Changes

- **Governance validation**
  - Enforce minimum and maximum timelock bounds for upgrade proposals.
  - Reject proposals with invalid thresholds or duplicate approvers.
  - Extend `GovernanceError` with upgrade-safety–specific error variants.
  - Ensure upgrade operations fail fast when governance is paused.

- **Emergency halt for upgrades**
  - Add governance-level `pause_governance` / `resume_governance` on `GovernanceManager`.
  - Integrate pause checks into `propose_upgrade`, `approve_proposal`, and `execute_proposal`.
  - Expose trading entrypoints to pause/resume upgrade governance via the admin.

- **Trading contract integration**
  - Initialize governance roles for admin/approvers/executor and persist them in shared storage so `GovernanceManager::require_role` can enforce access consistently.
  - Keep existing trading pause/unpause behavior, while adding a separate governance pause that only affects upgrade paths.

- **Storage and migration**
  - Use the optimized trading storage module for versioning, stats, and migration from legacy keys.
  - Align role storage so governance lookups can operate correctly across upgrades.

- **Testing & simulation**
  - Re-enable and extend the trading upgrade tests (e.g. `test_upgrade_proposal_flow_and_errors`).
  - Add coverage for:
    - Invalid thresholds and timelocks.
    - Duplicate approvals and unauthorized approvers.
    - Executing before and after timelock expiry.
    - Governance pause/resume behavior blocking and unblocking upgrades.

## Rationale

These changes reduce the risk of accidental or malicious upgrades by:
- Requiring meaningful timelocks and proper multi-sig approver sets.
- Providing an on-chain emergency halt for upgrade activity.
- Validating the full upgrade lifecycle through tests that simulate real-world failure modes.

## Testing

From `Contracts/`:

```bash
cargo test -p trading test_upgrade_proposal_flow_and_errors -- --nocapture
cargo test --all
```

All tests relevant to the trading upgrade flow pass.

closes issue #92 