### PR TITLE
feat(migration): add migration_samples (diagram, protos, marketplace scaffold, k6, grafana, CI, helm)

### DIFF
--- a/.github/workflows/marketplace-ci.yml
+++ b/.github/workflows/marketplace-ci.yml
@@ -1,0 +1,27 @@
+name: Marketplace CI
+
+on:
+  push:
+    paths:
+      - 'migration_samples/**'
+  pull_request:
+    paths:
+      - 'migration_samples/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: '1.70'
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Build
+        working-directory: migration_samples/marketplace_service
+        run: cargo build --release
+      - name: Run unit tests
+        working-directory: migration_samples/marketplace_service
+        run: cargo test

--- a/migration_samples/architecture/diagram.mmd
+++ b/migration_samples/architecture/diagram.mmd
@@ -1,0 +1,52 @@
+%% Mermaid architecture diagram for Stellara microservices
+flowchart LR
+  subgraph Gateway
+    Envoy[Envoy API Gateway]
+  end
+
+  subgraph Services
+    Identity[Identity Service]
+    Marketplace[Marketplace Service]
+    Payments[Payments Service]
+    Escrow[Escrow/Split Service]
+    Indexer[Indexer Service]
+    Notification[Notification Service]
+    Analytics[Analytics Service]
+    Reputation[Reputation Service]
+  end
+
+  subgraph Infra
+    NATS[NATS JetStream]
+    Postgres[Postgres (per-service DB)]
+    OTEL[OTEL Collector]
+    Jaeger[Jaeger]
+    Prom[Prometheus]
+    Grafana[Grafana]
+  end
+
+  Envoy -->|gRPC/HTTP| Marketplace
+  Envoy -->|gRPC/HTTP| Identity
+
+  Marketplace ---|gRPC| Payments
+  Marketplace ---|gRPC| Identity
+  Payments ---|gRPC| Identity
+
+  Indexer -->|events| NATS
+  Marketplace -->|events| NATS
+  Payments -->|events| NATS
+  Escrow -->|events| NATS
+  Identity -->|events| NATS
+
+  Notification -->|consumes| NATS
+  Analytics -->|consumes| NATS
+  Reputation -->|consumes| NATS
+
+  Services --> Postgres
+  Services --> OTEL
+  OTEL --> Jaeger
+  Services --> Prom
+  Prom --> Grafana
+
+  click NATS "https://nats.io" "NATS JetStream"
+  click Jaeger "https://www.jaegertracing.io/" "Jaeger"
+  click Prom "https://prometheus.io/" "Prometheus"

--- a/migration_samples/benchmarks/marketplace_k6.js
+++ b/migration_samples/benchmarks/marketplace_k6.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+  stages: [
+    { duration: '1m', target: 50 },
+    { duration: '3m', target: 200 },
+    { duration: '2m', target: 0 }
+  ],
+  thresholds: {
+    'http_req_duration': ['p(95)<500']
+  }
+};
+
+export default function () {
+  const BASE = __ENV.BASE_URL || 'http://localhost:8080';
+  let res = http.get(`${BASE}/health`);
+  check(res, { 'status is 200': (r) => r.status === 200 });
+
+  // simulate get listing
+  let id = Math.floor(Math.random() * 1000);
+  res = http.get(`${BASE}/listings/${id}`);
+  check(res, { 'get listing 200': (r) => r.status === 200 });
+  sleep(1);
+}

--- a/migration_samples/grafana/marketplace_dashboard.json
+++ b/migration_samples/grafana/marketplace_dashboard.json
@@ -1,0 +1,10 @@
+{
+  "annotations": {"list":[]},
+  "panels": [
+    {"type":"graph","title":"P95 Latency","targets":[],"id":1},
+    {"type":"graph","title":"Request Rate","targets":[],"id":2},
+    {"type":"graph","title":"Event Consumer Lag","targets":[],"id":3}
+  ],
+  "title": "Marketplace Service Overview",
+  "schemaVersion": 16
+}

--- a/migration_samples/helm/marketplace-service/Chart.yaml
+++ b/migration_samples/helm/marketplace-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: marketplace-service
+description: A Helm chart for the Stellara Marketplace service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/migration_samples/helm/marketplace-service/templates/_helpers.tpl
+++ b/migration_samples/helm/marketplace-service/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "marketplace-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "marketplace-service.fullname" -}}
+{{- printf "%s-%s" (include "marketplace-service.name" .) .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/migration_samples/helm/marketplace-service/templates/deployment.yaml
+++ b/migration_samples/helm/marketplace-service/templates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "marketplace-service.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "marketplace-service.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "marketplace-service.name" . }}
+    spec:
+      containers:
+        - name: marketplace
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080

--- a/migration_samples/helm/marketplace-service/templates/service.yaml
+++ b/migration_samples/helm/marketplace-service/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "marketplace-service.fullname" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "marketplace-service.name" . }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/migration_samples/helm/marketplace-service/values.yaml
+++ b/migration_samples/helm/marketplace-service/values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+
+image:
+  repository: stellara/marketplace
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources: {}

--- a/migration_samples/marketplace_service/Cargo.toml
+++ b/migration_samples/marketplace_service/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stellara-marketplace"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+axum = "0.7"
+tonic = { version = "0.9", features = ["transport"] }
+prost = "0.11"
+prost-types = "0.11"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+async-nats = "0.24"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sqlx = { version = "0.7", features=["postgres","runtime-tokio-native-tls","macros"] }
+
+[build-dependencies]
+tonic-build = "0.9"

--- a/migration_samples/marketplace_service/Dockerfile
+++ b/migration_samples/marketplace_service/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.70 as builder
+WORKDIR /usr/src/app
+COPY . .
+RUN apt-get update && apt-get install -y protobuf-compiler
+RUN cargo build --release
+
+FROM debian:buster-slim
+COPY --from=builder /usr/src/app/target/release/stellara-marketplace /usr/local/bin/stellara-marketplace
+EXPOSE 8080 50051
+CMD ["/usr/local/bin/stellara-marketplace"]

--- a/migration_samples/marketplace_service/build.rs
+++ b/migration_samples/marketplace_service/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .compile(&["../proto/marketplace.proto", "../proto/event.proto"], &["../proto"]) ?;
+    Ok(())
+}

--- a/migration_samples/marketplace_service/src/main.rs
+++ b/migration_samples/marketplace_service/src/main.rs
@@ -1,0 +1,61 @@
+use std::net::SocketAddr;
+use tonic::{transport::Server, Request, Response, Status};
+use prost_types::Timestamp;
+use tracing_subscriber;
+
+pub mod marketplace {
+    tonic::include_proto!("stellara.marketplace");
+}
+
+use marketplace::{marketplace_server::{Marketplace, MarketplaceServer}, CreateListingReq, CreateListingRes, GetListingReq, GetListingRes, Listing };
+
+#[derive(Default)]
+pub struct MarketplaceService {}
+
+#[tonic::async_trait]
+impl Marketplace for MarketplaceService {
+    async fn create_listing(&self, req: Request<CreateListingReq>) -> Result<Response<CreateListingRes>, Status> {
+        let listing = req.into_inner().listing.unwrap_or(Listing { id: "gen-1".into(), seller_id: "unknown".into(), title: "(empty)".into(), description: "".into(), price_cents: 0, currency: "USD".into(), created_at: None });
+        Ok(Response::new(CreateListingRes { listing: Some(listing) }))
+    }
+
+    async fn get_listing(&self, req: Request<GetListingReq>) -> Result<Response<GetListingRes>, Status> {
+        let id = req.into_inner().id;
+        let listing = Listing { id: id.clone(), seller_id: "seller-1".into(), title: "Sample".into(), description: "Sample listing".into(), price_cents: 1000, currency: "USD".into(), created_at: Some(Timestamp { seconds: 0, nanos: 0 }) };
+        Ok(Response::new(GetListingRes { listing: Some(listing) }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    // Start tonic gRPC server
+    let grpc_addr: SocketAddr = "0.0.0.0:50051".parse().unwrap();
+    let marketplace = MarketplaceService::default();
+
+    // Axum HTTP shim for external API
+    let http_addr: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+
+    let grpc_server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(MarketplaceServer::new(marketplace))
+            .serve(grpc_addr)
+            .await
+            .unwrap();
+    });
+
+    let app = axum::Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
+        .route("/listings/:id", axum::routing::get(|axum::extract::Path(id): axum::extract::Path<String>| async move { format!("listing {}", id) }));
+
+    let http_server = tokio::spawn(async move {
+        axum::Server::bind(&http_addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    tokio::try_join!(grpc_server, http_server)?;
+    Ok(())
+}

--- a/migration_samples/proto/event.proto
+++ b/migration_samples/proto/event.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package stellara.events;
+
+import "google/protobuf/timestamp.proto";
+
+message EventEnvelope {
+  string event_id = 1;
+  string source = 2;
+  string type = 3;
+  string version = 4;
+  google.protobuf.Timestamp ts = 5;
+  bytes payload = 6; // encoded payload (Protobuf of specific type)
+}

--- a/migration_samples/proto/marketplace.proto
+++ b/migration_samples/proto/marketplace.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+package stellara.marketplace;
+
+import "google/protobuf/timestamp.proto";
+
+message Listing {
+  string id = 1;
+  string seller_id = 2;
+  string title = 3;
+  string description = 4;
+  int64 price_cents = 5;
+  string currency = 6;
+  google.protobuf.Timestamp created_at = 7;
+}
+
+message CreateListingReq {
+  Listing listing = 1;
+}
+
+message CreateListingRes {
+  Listing listing = 1;
+}
+
+message GetListingReq {
+  string id = 1;
+}
+
+message GetListingRes {
+  Listing listing = 1;
+}
+
+service Marketplace {
+  rpc CreateListing(CreateListingReq) returns (CreateListingRes);
+  rpc GetListing(GetListingReq) returns (GetListingRes);
+}


### PR DESCRIPTION
Closes #157 


Summary: Add a set of migration artifacts and a minimal Marketplace Rust service scaffold to kickstart the monolith→microservice migration: architecture diagram, canonical event + marketplace protobufs, tonic/axum service skeleton, k6 benchmark, Grafana dashboard skeleton, GitHub Actions CI, and Helm chart.