### PR TITLE
feat(search): add OpenSearch integration, search service, indexer, mappings, and benchmarks

### DIFF
--- a/migration_samples/search/README.md
+++ b/migration_samples/search/README.md
@@ -1,0 +1,49 @@
+# Stellara Search - migration_samples/search
+
+This folder contains reference artifacts for integrating OpenSearch into Stellara and a minimal search service.
+
+Components
+- `opensearch/` - example index mappings for `academy`, `posts`, and `trading` indices.
+- `docker-compose.yml` - local OpenSearch + Dashboards for testing.
+- `search_service/` - Rust `axum` service that forwards query DSL to OpenSearch.
+- `indexer/` - simple Rust bulk indexer that ingests JSONL via the OpenSearch bulk API.
+- `benchmarks/` - `k6` scripts to simulate search traffic.
+- `grafana/` - dashboard skeleton for search metrics.
+
+Quickstart (local)
+
+1. Start OpenSearch and Dashboards:
+
+```bash
+cd "migration_samples/search"
+docker-compose up -d
+```
+
+2. Create index with mapping (example for posts):
+
+```bash
+curl -XPUT "http://localhost:9200/posts" -H 'Content-Type: application/json' --data-binary @opensearch/mappings_posts.json
+```
+
+3. Bulk index sample data with the indexer (requires Rust):
+
+```bash
+cd migration_samples/search/indexer
+cargo run --release -- -- (or set env: OPENSEARCH_URL, SEARCH_INDEX, BULK_FILE)
+```
+
+4. Run search service:
+
+```bash
+cd migration_samples/search/search_service
+OPENSEARCH_URL=http://localhost:9200 SEARCH_INDEX=posts cargo run
+```
+
+5. Run k6 benchmark (requires k6):
+
+```bash
+k6 run migration_samples/search/benchmarks/search_k6.js
+```
+
+Notes
+- This is a scaffold and reference implementation. For production, use secure OpenSearch deployment, TLS, auth, and stronger ingestion (Debezium/Kafka or NATS JetStream). Tune analyzers, shard counts, replicas, and refresh intervals to meet the 100ms P95 goal.

--- a/migration_samples/search/benchmarks/search_k6.js
+++ b/migration_samples/search/benchmarks/search_k6.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+  stages: [
+    { duration: '1m', target: 20 },
+    { duration: '3m', target: 100 },
+    { duration: '1m', target: 0 }
+  ],
+  thresholds: {
+    'http_req_duration': ['p(95)<100']
+  }
+};
+
+export default function () {
+  const BASE = __ENV.BASE_URL || 'http://localhost:8081';
+  let payload = JSON.stringify({ query: 'rust async', from: 0, size: 10 });
+  let params = { headers: { 'Content-Type': 'application/json' } };
+  let res = http.post(`${BASE}/v1/search`, payload, params);
+  check(res, { 'status 200': (r) => r.status === 200 });
+  sleep(1);
+}

--- a/migration_samples/search/docker-compose.yml
+++ b/migration_samples/search/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.10.2
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.10.2
+    environment:
+      - OPENSEARCH_HOSTS=http://opensearch:9200
+    ports:
+      - "5601:5601"
+
+volumes:
+  opensearch-data:

--- a/migration_samples/search/grafana/search_dashboard.json
+++ b/migration_samples/search/grafana/search_dashboard.json
@@ -1,0 +1,9 @@
+{
+  "title": "Search Service Overview",
+  "panels": [
+    { "id": 1, "title": "Search P95 Latency", "type": "graph" },
+    { "id": 2, "title": "Queries per Second", "type": "graph" },
+    { "id": 3, "title": "Zero-result Rate", "type": "stat" }
+  ],
+  "schemaVersion": 16
+}

--- a/migration_samples/search/indexer/Cargo.toml
+++ b/migration_samples/search/indexer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "stellara-search-indexer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"

--- a/migration_samples/search/indexer/sample_posts.jsonl
+++ b/migration_samples/search/indexer/sample_posts.jsonl
@@ -1,0 +1,2 @@
+{"id":"post-1","content":"Introduction to async Rust and building services","author_id":"author-1","hashtags":["rust","async"],"created_at":"2026-01-01T12:00:00Z","likes":10}
+{"id":"post-2","content":"How to scale search with OpenSearch and best practices","author_id":"author-2","hashtags":["search","opensearch"],"created_at":"2026-01-02T12:00:00Z","likes":5}

--- a/migration_samples/search/indexer/src/main.rs
+++ b/migration_samples/search/indexer/src/main.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde_json::Value;
+use std::{env, fs::File, io::{BufRead, BufReader}};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let opensearch = env::var("OPENSEARCH_URL").unwrap_or_else(|_| "http://localhost:9200".to_string());
+    let index = env::var("SEARCH_INDEX").unwrap_or_else(|_| "posts".to_string());
+    let file = env::var("BULK_FILE").unwrap_or_else(|_| "./sample_posts.jsonl".to_string());
+
+    let client = Client::new();
+    let f = File::open(&file)?;
+    let reader = BufReader::new(f);
+
+    let mut bulk = String::new();
+    let mut count = 0;
+    for line in reader.lines() {
+        let l = line?;
+        if l.trim().is_empty() { continue; }
+        // Bulk action header
+        let v: Value = serde_json::from_str(&l)?;
+        let id = v.get("id").and_then(|x| x.as_str()).unwrap_or("");
+        let action = serde_json::json!({ "index": { "_index": index, "_id": id }});
+        bulk.push_str(&serde_json::to_string(&action)?);
+        bulk.push('\n');
+        bulk.push_str(&l);
+        bulk.push('\n');
+        count += 1;
+
+        if count % 1000 == 0 {
+            let url = format!("{}/_bulk", opensearch.trim_end_matches('/'));
+            let res = client.post(&url).body(bulk.clone()).send().await?;
+            println!("bulk response: {}", res.status());
+            bulk.clear();
+        }
+    }
+
+    if !bulk.is_empty() {
+        let url = format!("{}/_bulk", opensearch.trim_end_matches('/'));
+        let res = client.post(&url).body(bulk.clone()).send().await?;
+        println!("final bulk response: {}", res.status());
+    }
+
+    Ok(())
+}

--- a/migration_samples/search/opensearch/mappings_academy.json
+++ b/migration_samples/search/opensearch/mappings_academy.json
@@ -1,0 +1,37 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "english_custom": { "type": "standard", "stopwords": "_english_" },
+        "edge_ngram_analyzer": {
+          "tokenizer": "edge_ngram_tokenizer",
+          "filter": ["lowercase"]
+        }
+      },
+      "tokenizer": {
+        "edge_ngram_tokenizer": {
+          "type": "edge_ngram",
+          "min_gram": 2,
+          "max_gram": 20,
+          "token_chars": ["letter", "digit"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "id": { "type": "keyword" },
+      "title": {
+        "type": "text",
+        "analyzer": "english_custom",
+        "fields": { "raw": { "type": "keyword" }, "edge": { "type": "text", "analyzer": "edge_ngram_analyzer" } }
+      },
+      "body": { "type": "text", "analyzer": "english_custom" },
+      "author_id": { "type": "keyword" },
+      "tags": { "type": "keyword" },
+      "published_at": { "type": "date" },
+      "views": { "type": "long" },
+      "vector": { "type": "dense_vector", "dims": 768 }
+    }
+  }
+}

--- a/migration_samples/search/opensearch/mappings_posts.json
+++ b/migration_samples/search/opensearch/mappings_posts.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "english_custom": { "type": "standard", "stopwords": "_english_" },
+        "edge_ngram_analyzer": { "tokenizer": "edge_ngram_tokenizer", "filter": ["lowercase"] }
+      },
+      "tokenizer": { "edge_ngram_tokenizer": { "type": "edge_ngram", "min_gram": 2, "max_gram": 20, "token_chars": ["letter","digit"] } }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "id": { "type": "keyword" },
+      "content": { "type": "text", "analyzer": "english_custom" },
+      "author_id": { "type": "keyword" },
+      "assets": { "type": "keyword" },
+      "hashtags": { "type": "keyword" },
+      "created_at": { "type": "date" },
+      "likes": { "type": "long" },
+      "comments_count": { "type": "long" },
+      "edge_title": { "type": "text", "analyzer": "edge_ngram_analyzer" }
+    }
+  }
+}

--- a/migration_samples/search/opensearch/mappings_trading.json
+++ b/migration_samples/search/opensearch/mappings_trading.json
@@ -1,0 +1,17 @@
+{
+  "settings": {
+    "analysis": { }
+  },
+  "mappings": {
+    "properties": {
+      "id": { "type": "keyword" },
+      "symbol": { "type": "keyword" },
+      "title": { "type": "text", "analyzer": "standard" },
+      "description": { "type": "text", "analyzer": "english" },
+      "market": { "type": "keyword" },
+      "price": { "type": "double" },
+      "volume": { "type": "double" },
+      "created_at": { "type": "date" }
+    }
+  }
+}

--- a/migration_samples/search/search_service/Cargo.toml
+++ b/migration_samples/search/search_service/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "stellara-search-service"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+axum = "0.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+reqwest = { version = "0.11", features = ["json","gzip","brotli","stream"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+dotenv = "0.15"

--- a/migration_samples/search/search_service/src/main.rs
+++ b/migration_samples/search/search_service/src/main.rs
@@ -1,0 +1,71 @@
+use axum::{extract::Json, http::StatusCode, routing::post, Router};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::env;
+use tracing_subscriber;
+
+#[derive(Debug, Deserialize)]
+struct SearchRequest {
+    query: String,
+    filters: Option<serde_json::Value>,
+    from: Option<u32>,
+    size: Option<u32>
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let app = Router::new().route("/v1/search", post(handle_search));
+
+    let port = env::var("PORT").unwrap_or_else(|_| "8081".to_string());
+    let addr = format!("0.0.0.0:{}", port);
+
+    tracing::info!("Starting search service on {}", addr);
+    axum::Server::bind(&addr.parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn handle_search(Json(payload): Json<SearchRequest>) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let opensearch = env::var("OPENSEARCH_URL").unwrap_or_else(|_| "http://localhost:9200".to_string());
+    let index = env::var("SEARCH_INDEX").unwrap_or_else(|_| "posts".to_string());
+
+    // Build a basic OpenSearch/Elasticsearch query
+    let mut query_body = serde_json::json!({
+        "from": payload.from.unwrap_or(0),
+        "size": payload.size.unwrap_or(20),
+        "query": {
+            "bool": {
+                "must": [
+                    { "multi_match": { "query": payload.query, "fields": ["title^3","content","body"] } }
+                ]
+            }
+        }
+    });
+
+    if let Some(filters) = payload.filters {
+        // Attach filters as filter clause
+        query_body["query"]["bool"]["filter"] = serde_json::Value::Array(vec![filters]);
+    }
+
+    let client = Client::new();
+    let url = format!("{}/{}/_search", opensearch.trim_end_matches('/'), index);
+    let res = client.post(&url).json(&query_body).send().await.map_err(|e| (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse { error: format!("upstream error: {}", e) })
+    ))?;
+
+    let json: serde_json::Value = res.json().await.map_err(|e| (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse { error: format!("invalid upstream response: {}", e) })
+    ))?;
+
+    Ok(Json(json))
+}


### PR DESCRIPTION
Closes #158 

Summary
Adds a reference OpenSearch integration and a minimal, production-oriented search stack to enable full-text search, faceted filtering, ranking experiments, and performance validation for academy content, social posts, and trading data.

What this PR includes
Index mappings and analyzers for domain indices:
[mappings_academy.json](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[mappings_posts.json](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[mappings_trading.json](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Local test environment:
[docker-compose.yml](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (OpenSearch + Dashboards)
Runtime components:
[search_service](vscode-file://vscode-app/c:/Users/u-adamu/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (Rust axum service forwarding DSL to OpenSearch)