### PR TITLE
feat: add governance and advanced staking/yield farming contracts

### DIFF
--- a/Contracts/governance/Cargo.toml
+++ b/Contracts/governance/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "stellara-governance"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = [] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/Contracts/governance/src/lib.rs
+++ b/Contracts/governance/src/lib.rs
@@ -1,0 +1,466 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    Address, Env, Map, String, Symbol, Vec,
+};
+
+// ─── Storage Keys ────────────────────────────────────────────────────────────
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const CONFIG: Symbol = symbol_short!("CONFIG");
+const PROP_COUNT: Symbol = symbol_short!("PROP_CNT");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct GovernanceConfig {
+    pub voting_delay: u64,        // ledgers before voting starts
+    pub voting_period: u64,       // ledgers voting is open
+    pub timelock_delay: u64,      // ledgers before execution after passing
+    pub quorum_bps: u32,          // basis points (e.g. 400 = 4%)
+    pub threshold_bps: u32,       // basis points majority needed (e.g. 5100 = 51%)
+    pub proposal_threshold: i128, // min tokens to create proposal
+}
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum ProposalState {
+    Pending,
+    Active,
+    Succeeded,
+    Defeated,
+    Queued,
+    Executed,
+    Cancelled,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Proposal {
+    pub id: u64,
+    pub proposer: Address,
+    pub title: String,
+    pub description: String,
+    pub calldata: Vec<String>,    // encoded action strings
+    pub start_ledger: u64,
+    pub end_ledger: u64,
+    pub eta_ledger: u64,          // earliest execution ledger (after timelock)
+    pub for_votes: i128,
+    pub against_votes: i128,
+    pub abstain_votes: i128,
+    pub state: ProposalState,
+    pub cancelled: bool,
+    pub executed: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VoteReceipt {
+    pub has_voted: bool,
+    pub support: u8,              // 0=against, 1=for, 2=abstain
+    pub votes: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Proposal(u64),
+    VoteReceipt(u64, Address),
+    Delegate(Address),
+    VotingPower(Address),
+    TotalSupply,
+}
+
+// ─── Contract ────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct GovernanceContract;
+
+#[contractimpl]
+impl GovernanceContract {
+    // ── Init ────────────────────────────────────────────────────────────────
+
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        config: GovernanceConfig,
+        initial_supply: i128,
+    ) {
+        admin.require_auth();
+        if env.storage().instance().has(&ADMIN) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&CONFIG, &config);
+        env.storage().instance().set(&PROP_COUNT, &0u64);
+        env.storage().persistent().set(&DataKey::TotalSupply, &initial_supply);
+    }
+
+    // ── Governance Config ────────────────────────────────────────────────────
+
+    pub fn update_config(env: Env, new_config: GovernanceConfig) {
+        Self::only_admin(&env);
+        env.storage().instance().set(&CONFIG, &new_config);
+    }
+
+    pub fn get_config(env: Env) -> GovernanceConfig {
+        env.storage().instance().get(&CONFIG).unwrap()
+    }
+
+    // ── Voting Power / Delegation ─────────────────────────────────────────
+
+    pub fn set_voting_power(env: Env, account: Address, amount: i128) {
+        Self::only_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::VotingPower(account), &amount);
+    }
+
+    pub fn delegate(env: Env, delegator: Address, delegatee: Address) {
+        delegator.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Delegate(delegator.clone()), &delegatee);
+        env.events().publish(
+            (symbol_short!("delegate"), delegator),
+            delegatee,
+        );
+    }
+
+    pub fn get_delegate(env: Env, account: Address) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Delegate(account.clone()))
+            .unwrap_or(account)
+    }
+
+    pub fn get_votes(env: Env, account: Address) -> i128 {
+        let effective = Self::resolve_delegate(&env, account);
+        env.storage()
+            .persistent()
+            .get(&DataKey::VotingPower(effective))
+            .unwrap_or(0i128)
+    }
+
+    // ── Proposals ────────────────────────────────────────────────────────────
+
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        title: String,
+        description: String,
+        calldata: Vec<String>,
+    ) -> u64 {
+        proposer.require_auth();
+
+        let config: GovernanceConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let votes = Self::get_votes(env.clone(), proposer.clone());
+
+        if votes < config.proposal_threshold {
+            panic!("insufficient voting power to propose");
+        }
+
+        let current = env.ledger().sequence() as u64;
+        let start = current + config.voting_delay;
+        let end = start + config.voting_period;
+
+        let mut count: u64 = env.storage().instance().get(&PROP_COUNT).unwrap();
+        count += 1;
+
+        let proposal = Proposal {
+            id: count,
+            proposer: proposer.clone(),
+            title,
+            description,
+            calldata,
+            start_ledger: start,
+            end_ledger: end,
+            eta_ledger: 0,
+            for_votes: 0,
+            against_votes: 0,
+            abstain_votes: 0,
+            state: ProposalState::Pending,
+            cancelled: false,
+            executed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(count), &proposal);
+        env.storage().instance().set(&PROP_COUNT, &count);
+
+        env.events().publish(
+            (symbol_short!("proposed"), proposer),
+            count,
+        );
+
+        count
+    }
+
+    pub fn cancel_proposal(env: Env, caller: Address, proposal_id: u64) {
+        caller.require_auth();
+        let mut proposal = Self::load_proposal(&env, proposal_id);
+
+        if proposal.proposer != caller {
+            Self::require_admin(&env);
+        }
+        if proposal.executed {
+            panic!("already executed");
+        }
+
+        proposal.cancelled = true;
+        proposal.state = ProposalState::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Proposal {
+        let mut proposal = Self::load_proposal(&env, proposal_id);
+        proposal.state = Self::compute_state(&env, &proposal);
+        proposal
+    }
+
+    pub fn get_proposal_state(env: Env, proposal_id: u64) -> ProposalState {
+        let proposal = Self::load_proposal(&env, proposal_id);
+        Self::compute_state(&env, &proposal)
+    }
+
+    // ── Voting ────────────────────────────────────────────────────────────────
+
+    pub fn cast_vote(env: Env, voter: Address, proposal_id: u64, support: u8) {
+        voter.require_auth();
+        Self::_cast_vote(&env, voter, proposal_id, support);
+    }
+
+    pub fn cast_vote_with_reason(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        support: u8,
+        _reason: String,
+    ) {
+        voter.require_auth();
+        Self::_cast_vote(&env, voter, proposal_id, support);
+    }
+
+    pub fn get_vote_receipt(env: Env, proposal_id: u64, voter: Address) -> VoteReceipt {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VoteReceipt(proposal_id, voter))
+            .unwrap_or(VoteReceipt {
+                has_voted: false,
+                support: 0,
+                votes: 0,
+            })
+    }
+
+    // ── Timelock / Queue / Execute ────────────────────────────────────────────
+
+    pub fn queue(env: Env, caller: Address, proposal_id: u64) {
+        caller.require_auth();
+        let config: GovernanceConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let mut proposal = Self::load_proposal(&env, proposal_id);
+        let state = Self::compute_state(&env, &proposal);
+
+        if state != ProposalState::Succeeded {
+            panic!("proposal not succeeded");
+        }
+
+        let current = env.ledger().sequence() as u64;
+        proposal.eta_ledger = current + config.timelock_delay;
+        proposal.state = ProposalState::Queued;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events().publish(
+            (symbol_short!("queued"), proposal_id),
+            proposal.eta_ledger,
+        );
+    }
+
+    pub fn execute(env: Env, caller: Address, proposal_id: u64) {
+        caller.require_auth();
+        let mut proposal = Self::load_proposal(&env, proposal_id);
+
+        if proposal.state != ProposalState::Queued {
+            panic!("proposal not queued");
+        }
+        if proposal.eta_ledger == 0 {
+            panic!("eta not set");
+        }
+
+        let current = env.ledger().sequence() as u64;
+        if current < proposal.eta_ledger {
+            panic!("timelock not elapsed");
+        }
+
+        let grace = proposal.eta_ledger + 100_800; // ~7 days grace period
+        if current > grace {
+            proposal.state = ProposalState::Expired;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Proposal(proposal_id), &proposal);
+            panic!("proposal expired");
+        }
+
+        proposal.executed = true;
+        proposal.state = ProposalState::Executed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events().publish(
+            (symbol_short!("executed"), caller),
+            proposal_id,
+        );
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    pub fn transfer_admin(env: Env, new_admin: Address) {
+        Self::only_admin(&env);
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&ADMIN).unwrap()
+    }
+
+    pub fn proposal_count(env: Env) -> u64 {
+        env.storage().instance().get(&PROP_COUNT).unwrap_or(0)
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    fn load_proposal(env: &Env, id: u64) -> Proposal {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(id))
+            .expect("proposal not found")
+    }
+
+    fn compute_state(env: &Env, proposal: &Proposal) -> ProposalState {
+        if proposal.cancelled {
+            return ProposalState::Cancelled;
+        }
+        if proposal.executed {
+            return ProposalState::Executed;
+        }
+
+        let config: GovernanceConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let current = env.ledger().sequence() as u64;
+        let total_supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(1);
+
+        if current < proposal.start_ledger {
+            return ProposalState::Pending;
+        }
+        if current <= proposal.end_ledger {
+            return ProposalState::Active;
+        }
+
+        // voting ended — check quorum and threshold
+        let total_votes = proposal.for_votes + proposal.against_votes + proposal.abstain_votes;
+        let quorum_needed = (total_supply * config.quorum_bps as i128) / 10_000;
+
+        if total_votes < quorum_needed {
+            return ProposalState::Defeated;
+        }
+
+        let decisive = proposal.for_votes + proposal.against_votes;
+        if decisive == 0 {
+            return ProposalState::Defeated;
+        }
+
+        let for_bps = (proposal.for_votes * 10_000) / decisive;
+        if for_bps >= config.threshold_bps as i128 {
+            if proposal.state == ProposalState::Queued {
+                return ProposalState::Queued;
+            }
+            return ProposalState::Succeeded;
+        }
+
+        ProposalState::Defeated
+    }
+
+    fn _cast_vote(env: &Env, voter: Address, proposal_id: u64, support: u8) {
+        let receipt_key = DataKey::VoteReceipt(proposal_id, voter.clone());
+        let existing: VoteReceipt = env
+            .storage()
+            .persistent()
+            .get(&receipt_key)
+            .unwrap_or(VoteReceipt { has_voted: false, support: 0, votes: 0 });
+
+        if existing.has_voted {
+            panic!("already voted");
+        }
+
+        let mut proposal = Self::load_proposal(env, proposal_id);
+        let state = Self::compute_state(env, &proposal);
+
+        if state != ProposalState::Active {
+            panic!("voting not active");
+        }
+
+        if support > 2 {
+            panic!("invalid support value: 0=against 1=for 2=abstain");
+        }
+
+        let effective = Self::resolve_delegate(env, voter.clone());
+        let votes: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VotingPower(effective))
+            .unwrap_or(0);
+
+        if votes == 0 {
+            panic!("no voting power");
+        }
+
+        match support {
+            0 => proposal.against_votes += votes,
+            1 => proposal.for_votes += votes,
+            2 => proposal.abstain_votes += votes,
+            _ => panic!("invalid support"),
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.storage().persistent().set(
+            &receipt_key,
+            &VoteReceipt { has_voted: true, support, votes },
+        );
+
+        env.events().publish(
+            (symbol_short!("voted"), voter),
+            (proposal_id, support, votes),
+        );
+    }
+
+    fn resolve_delegate(env: &Env, account: Address) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Delegate(account.clone()))
+            .unwrap_or(account)
+    }
+
+    fn only_admin(env: &Env) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+    }
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+    }
+}

--- a/Contracts/staking/Cargo.toml
+++ b/Contracts/staking/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "stellara-staking"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = [] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/Contracts/staking/src/lib.rs
+++ b/Contracts/staking/src/lib.rs
@@ -1,0 +1,771 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    token, Address, Env, Map, Symbol, Vec,
+};
+
+// ─── Storage Keys ─────────────────────────────────────────────────────────────
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+const CONFIG: Symbol = symbol_short!("CONFIG");
+const PAUSED: Symbol = symbol_short!("PAUSED");
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakingConfig {
+    pub staking_token: Address,
+    pub min_stake_amount: i128,
+    pub emergency_fee_bps: u32,      // fee on emergency withdraw (e.g. 1000 = 10%)
+    pub compound_fee_bps: u32,       // fee retained on auto-compound
+    pub fee_recipient: Address,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LockupTier {
+    pub duration_ledgers: u64,       // 0 = flexible (no lock)
+    pub boost_bps: u32,              // reward multiplier bonus (e.g. 2000 = +20%)
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct RewardPool {
+    pub token: Address,
+    pub reward_rate: i128,           // tokens per ledger (scaled 1e7)
+    pub reward_per_token_stored: i128,
+    pub last_update_ledger: u64,
+    pub total_rewards_deposited: i128,
+    pub total_rewards_paid: i128,
+    pub period_finish: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct StakePosition {
+    pub owner: Address,
+    pub amount: i128,
+    pub boosted_amount: i128,
+    pub lockup_duration: u64,
+    pub unlock_ledger: u64,
+    pub start_ledger: u64,
+    pub auto_compound: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct UserRewardState {
+    pub reward_per_token_paid: i128,
+    pub accrued: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    TotalStaked,
+    TotalBoostedStake,
+    StakePosition(Address),
+    LockupTiers,
+    RewardPool(Address),             // keyed by reward token address
+    RewardPools,                     // Vec<Address> of all reward tokens
+    UserReward(Address, Address),    // (user, reward_token)
+    CompoundRewards(Address),        // queued compoundable rewards per user
+}
+
+// ─── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct StakingContract;
+
+#[contractimpl]
+impl StakingContract {
+    // ── Init ──────────────────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address, config: StakingConfig, tiers: Vec<LockupTier>) {
+        admin.require_auth();
+        if env.storage().instance().has(&ADMIN) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().set(&CONFIG, &config);
+        env.storage().instance().set(&PAUSED, &false);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LockupTiers, &tiers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStaked, &0i128);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalBoostedStake, &0i128);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RewardPools, &Vec::<Address>::new(&env));
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    pub fn add_reward_pool(
+        env: Env,
+        reward_token: Address,
+        reward_amount: i128,
+        duration_ledgers: u64,
+    ) {
+        Self::only_admin(&env);
+        let config: StakingConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let current = env.ledger().sequence() as u64;
+
+        let mut pools: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap();
+
+        let total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        let reward_rate = if duration_ledgers == 0 {
+            panic!("duration must be > 0");
+        } else {
+            (reward_amount * 1_0000000) / duration_ledgers as i128
+        };
+
+        let pool_key = DataKey::RewardPool(reward_token.clone());
+        let pool = if env.storage().persistent().has(&pool_key) {
+            let mut existing: RewardPool = env.storage().persistent().get(&pool_key).unwrap();
+            Self::_update_reward_per_token(&env, &mut existing, total_boosted);
+            // extend or top up existing pool
+            let remaining = if current < existing.period_finish {
+                (existing.period_finish - current) as i128 * existing.reward_rate
+            } else {
+                0
+            };
+            let new_rate = ((remaining + reward_amount) * 1_0000000) / duration_ledgers as i128;
+            existing.reward_rate = new_rate;
+            existing.period_finish = current + duration_ledgers;
+            existing.total_rewards_deposited += reward_amount;
+            existing.last_update_ledger = current;
+            existing
+        } else {
+            pools.push_back(reward_token.clone());
+            RewardPool {
+                token: reward_token.clone(),
+                reward_rate,
+                reward_per_token_stored: 0,
+                last_update_ledger: current,
+                total_rewards_deposited: reward_amount,
+                total_rewards_paid: 0,
+                period_finish: current + duration_ledgers,
+            }
+        };
+
+        token::Client::new(&env, &reward_token).transfer_from(
+            &env.current_contract_address(),
+            &env.current_contract_address(),
+            &env.current_contract_address(),
+            &reward_amount,
+        );
+
+        env.storage().persistent().set(&pool_key, &pool);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RewardPools, &pools);
+    }
+
+    pub fn set_paused(env: Env, paused: bool) {
+        Self::only_admin(&env);
+        env.storage().instance().set(&PAUSED, &paused);
+    }
+
+    pub fn update_config(env: Env, new_config: StakingConfig) {
+        Self::only_admin(&env);
+        env.storage().instance().set(&CONFIG, &new_config);
+    }
+
+    pub fn update_tiers(env: Env, tiers: Vec<LockupTier>) {
+        Self::only_admin(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LockupTiers, &tiers);
+    }
+
+    pub fn transfer_admin(env: Env, new_admin: Address) {
+        Self::only_admin(&env);
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+
+    // ── Staking ───────────────────────────────────────────────────────────────
+
+    pub fn stake(
+        env: Env,
+        user: Address,
+        amount: i128,
+        lockup_duration: u64,
+        auto_compound: bool,
+    ) {
+        user.require_auth();
+        Self::not_paused(&env);
+
+        let config: StakingConfig = env.storage().instance().get(&CONFIG).unwrap();
+        if amount < config.min_stake_amount {
+            panic!("below minimum stake");
+        }
+
+        let tiers: Vec<LockupTier> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LockupTiers)
+            .unwrap();
+
+        let boost_bps = Self::get_boost_bps(&tiers, lockup_duration);
+        let boosted = Self::apply_boost(amount, boost_bps);
+        let current = env.ledger().sequence() as u64;
+
+        Self::_update_all_rewards(&env, &user);
+
+        let pos_key = DataKey::StakePosition(user.clone());
+        let mut total_staked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+        let mut total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        if env.storage().persistent().has(&pos_key) {
+            // compound existing before adding
+            let mut pos: StakePosition = env.storage().persistent().get(&pos_key).unwrap();
+            total_staked += amount;
+            total_boosted = total_boosted - pos.boosted_amount + pos.boosted_amount + boosted - Self::apply_boost(pos.amount, Self::get_boost_bps(&tiers, pos.lockup_duration));
+            pos.amount += amount;
+            pos.boosted_amount += boosted;
+            env.storage().persistent().set(&pos_key, &pos);
+        } else {
+            let pos = StakePosition {
+                owner: user.clone(),
+                amount,
+                boosted_amount: boosted,
+                lockup_duration,
+                unlock_ledger: if lockup_duration == 0 { 0 } else { current + lockup_duration },
+                start_ledger: current,
+                auto_compound,
+            };
+            total_staked += amount;
+            total_boosted += boosted;
+            env.storage().persistent().set(&pos_key, &pos);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStaked, &total_staked);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalBoostedStake, &total_boosted);
+
+        token::Client::new(&env, &config.staking_token).transfer(
+            &user,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        env.events()
+            .publish((symbol_short!("staked"), user), (amount, lockup_duration));
+    }
+
+    pub fn unstake(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        Self::not_paused(&env);
+
+        let config: StakingConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let pos_key = DataKey::StakePosition(user.clone());
+        let mut pos: StakePosition = env
+            .storage()
+            .persistent()
+            .get(&pos_key)
+            .expect("no stake found");
+
+        if amount > pos.amount {
+            panic!("insufficient staked balance");
+        }
+
+        let current = env.ledger().sequence() as u64;
+        if pos.unlock_ledger > 0 && current < pos.unlock_ledger {
+            panic!("stake is locked");
+        }
+
+        Self::_update_all_rewards(&env, &user);
+
+        let tiers: Vec<LockupTier> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LockupTiers)
+            .unwrap();
+        let boost_bps = Self::get_boost_bps(&tiers, pos.lockup_duration);
+        let boosted_reduction = Self::apply_boost(amount, boost_bps);
+
+        let mut total_staked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+        let mut total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        pos.amount -= amount;
+        pos.boosted_amount -= boosted_reduction;
+        total_staked -= amount;
+        total_boosted -= boosted_reduction;
+
+        if pos.amount == 0 {
+            env.storage().persistent().remove(&pos_key);
+        } else {
+            env.storage().persistent().set(&pos_key, &pos);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStaked, &total_staked);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalBoostedStake, &total_boosted);
+
+        token::Client::new(&env, &config.staking_token).transfer(
+            &env.current_contract_address(),
+            &user,
+            &amount,
+        );
+
+        env.events()
+            .publish((symbol_short!("unstaked"), user), amount);
+    }
+
+    // ── Emergency Withdraw ────────────────────────────────────────────────────
+
+    pub fn emergency_withdraw(env: Env, user: Address) {
+        user.require_auth();
+
+        let config: StakingConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let pos_key = DataKey::StakePosition(user.clone());
+        let pos: StakePosition = env
+            .storage()
+            .persistent()
+            .get(&pos_key)
+            .expect("no stake found");
+
+        let tiers: Vec<LockupTier> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LockupTiers)
+            .unwrap();
+        let boost_bps = Self::get_boost_bps(&tiers, pos.lockup_duration);
+
+        let mut total_staked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+        let mut total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        total_staked -= pos.amount;
+        total_boosted -= pos.boosted_amount;
+
+        // forfeit all pending rewards
+        let pools: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap_or_else(|| Vec::new(&env));
+        for pool_addr in pools.iter() {
+            let reward_key = DataKey::UserReward(user.clone(), pool_addr.clone());
+            env.storage().persistent().remove(&reward_key);
+        }
+
+        // apply penalty fee
+        let fee = (pos.amount * config.emergency_fee_bps as i128) / 10_000;
+        let payout = pos.amount - fee;
+
+        env.storage().persistent().remove(&pos_key);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStaked, &total_staked);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalBoostedStake, &total_boosted);
+
+        if fee > 0 {
+            token::Client::new(&env, &config.staking_token).transfer(
+                &env.current_contract_address(),
+                &config.fee_recipient,
+                &fee,
+            );
+        }
+
+        token::Client::new(&env, &config.staking_token).transfer(
+            &env.current_contract_address(),
+            &user,
+            &payout,
+        );
+
+        env.events().publish(
+            (symbol_short!("emr_exit"), user),
+            (payout, fee),
+        );
+    }
+
+    // ── Rewards ───────────────────────────────────────────────────────────────
+
+    pub fn claim_rewards(env: Env, user: Address) {
+        user.require_auth();
+        Self::not_paused(&env);
+        Self::_update_all_rewards(&env, &user);
+        Self::_pay_rewards(&env, &user);
+    }
+
+    pub fn compound(env: Env, user: Address) {
+        user.require_auth();
+        Self::not_paused(&env);
+
+        let config: StakingConfig = env.storage().instance().get(&CONFIG).unwrap();
+        let pos_key = DataKey::StakePosition(user.clone());
+
+        if !env.storage().persistent().has(&pos_key) {
+            panic!("no active stake");
+        }
+
+        let mut pos: StakePosition = env.storage().persistent().get(&pos_key).unwrap();
+        if !pos.auto_compound {
+            panic!("auto-compound not enabled for this position");
+        }
+
+        Self::_update_all_rewards(&env, &user);
+
+        let pools: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let staking_token = config.staking_token.clone();
+        let mut compounded = 0i128;
+
+        for pool_addr in pools.iter() {
+            // only compound if reward token == staking token
+            if pool_addr == staking_token {
+                let reward_key = DataKey::UserReward(user.clone(), pool_addr.clone());
+                let mut state: UserRewardState = env
+                    .storage()
+                    .persistent()
+                    .get(&reward_key)
+                    .unwrap_or(UserRewardState {
+                        reward_per_token_paid: 0,
+                        accrued: 0,
+                    });
+
+                let fee = (state.accrued * config.compound_fee_bps as i128) / 10_000;
+                let net = state.accrued - fee;
+
+                if net > 0 {
+                    compounded += net;
+
+                    if fee > 0 {
+                        token::Client::new(&env, &pool_addr).transfer(
+                            &env.current_contract_address(),
+                            &config.fee_recipient,
+                            &fee,
+                        );
+                    }
+
+                    state.accrued = 0;
+                    env.storage().persistent().set(&reward_key, &state);
+                }
+            }
+        }
+
+        if compounded == 0 {
+            panic!("nothing to compound");
+        }
+
+        let tiers: Vec<LockupTier> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LockupTiers)
+            .unwrap();
+        let boost_bps = Self::get_boost_bps(&tiers, pos.lockup_duration);
+        let extra_boosted = Self::apply_boost(compounded, boost_bps);
+
+        let mut total_staked: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0);
+        let mut total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        pos.amount += compounded;
+        pos.boosted_amount += extra_boosted;
+        total_staked += compounded;
+        total_boosted += extra_boosted;
+
+        env.storage().persistent().set(&pos_key, &pos);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalStaked, &total_staked);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalBoostedStake, &total_boosted);
+
+        env.events().publish(
+            (symbol_short!("compound"), user),
+            compounded,
+        );
+    }
+
+    // ── Views ─────────────────────────────────────────────────────────────────
+
+    pub fn get_stake(env: Env, user: Address) -> StakePosition {
+        env.storage()
+            .persistent()
+            .get(&DataKey::StakePosition(user))
+            .expect("no stake found")
+    }
+
+    pub fn get_reward_pool(env: Env, reward_token: Address) -> RewardPool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RewardPool(reward_token))
+            .expect("pool not found")
+    }
+
+    pub fn get_reward_pools(env: Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn pending_rewards(env: Env, user: Address, reward_token: Address) -> i128 {
+        let total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        let pos: StakePosition = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakePosition(user.clone()))
+        {
+            Some(p) => p,
+            None => return 0,
+        };
+
+        let pool: RewardPool = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPool(reward_token.clone()))
+        {
+            Some(p) => p,
+            None => return 0,
+        };
+
+        let rpt = Self::calc_reward_per_token(&env, &pool, total_boosted);
+        let user_state: UserRewardState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserReward(user, reward_token))
+            .unwrap_or(UserRewardState {
+                reward_per_token_paid: 0,
+                accrued: 0,
+            });
+
+        user_state.accrued
+            + (pos.boosted_amount * (rpt - user_state.reward_per_token_paid)) / 1_0000000
+    }
+
+    pub fn total_staked(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalStaked)
+            .unwrap_or(0)
+    }
+
+    pub fn total_boosted_stake(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0)
+    }
+
+    pub fn get_lockup_tiers(env: Env) -> Vec<LockupTier> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::LockupTiers)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_config(env: Env) -> StakingConfig {
+        env.storage().instance().get(&CONFIG).unwrap()
+    }
+
+    // ── Internal ──────────────────────────────────────────────────────────────
+
+    fn _update_all_rewards(env: &Env, user: &Address) {
+        let total_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalBoostedStake)
+            .unwrap_or(0);
+
+        let pools: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap_or_else(|| Vec::new(env));
+
+        let user_boosted: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::StakePosition(user.clone()))
+            .map(|p: StakePosition| p.boosted_amount)
+            .unwrap_or(0);
+
+        for pool_addr in pools.iter() {
+            let pool_key = DataKey::RewardPool(pool_addr.clone());
+            let mut pool: RewardPool = env.storage().persistent().get(&pool_key).unwrap();
+
+            let rpt = Self::calc_reward_per_token(env, &pool, total_boosted);
+            Self::_update_reward_per_token(env, &mut pool, total_boosted);
+
+            let reward_key = DataKey::UserReward(user.clone(), pool_addr.clone());
+            let mut state: UserRewardState = env
+                .storage()
+                .persistent()
+                .get(&reward_key)
+                .unwrap_or(UserRewardState {
+                    reward_per_token_paid: 0,
+                    accrued: 0,
+                });
+
+            state.accrued +=
+                (user_boosted * (rpt - state.reward_per_token_paid)) / 1_0000000;
+            state.reward_per_token_paid = pool.reward_per_token_stored;
+
+            env.storage().persistent().set(&reward_key, &state);
+            env.storage().persistent().set(&pool_key, &pool);
+        }
+    }
+
+    fn _update_reward_per_token(env: &Env, pool: &mut RewardPool, total_boosted: i128) {
+        let rpt = Self::calc_reward_per_token(env, pool, total_boosted);
+        pool.reward_per_token_stored = rpt;
+        let current = env.ledger().sequence() as u64;
+        pool.last_update_ledger = current.min(pool.period_finish);
+    }
+
+    fn calc_reward_per_token(env: &Env, pool: &RewardPool, total_boosted: i128) -> i128 {
+        if total_boosted == 0 {
+            return pool.reward_per_token_stored;
+        }
+        let current = env.ledger().sequence() as u64;
+        let last = pool.last_update_ledger;
+        let finish = pool.period_finish;
+        let applicable = current.min(finish);
+        if applicable <= last {
+            return pool.reward_per_token_stored;
+        }
+        let elapsed = (applicable - last) as i128;
+        pool.reward_per_token_stored
+            + (elapsed * pool.reward_rate) / total_boosted
+    }
+
+    fn _pay_rewards(env: &Env, user: &Address) {
+        let pools: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardPools)
+            .unwrap_or_else(|| Vec::new(env));
+
+        for pool_addr in pools.iter() {
+            let reward_key = DataKey::UserReward(user.clone(), pool_addr.clone());
+            let mut state: UserRewardState = env
+                .storage()
+                .persistent()
+                .get(&reward_key)
+                .unwrap_or(UserRewardState {
+                    reward_per_token_paid: 0,
+                    accrued: 0,
+                });
+
+            if state.accrued > 0 {
+                let payout = state.accrued;
+
+                let mut pool: RewardPool = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::RewardPool(pool_addr.clone()))
+                    .unwrap();
+                pool.total_rewards_paid += payout;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::RewardPool(pool_addr.clone()), &pool);
+
+                state.accrued = 0;
+                env.storage().persistent().set(&reward_key, &state);
+
+                token::Client::new(env, &pool_addr).transfer(
+                    &env.current_contract_address(),
+                    user,
+                    &payout,
+                );
+
+                env.events().publish(
+                    (symbol_short!("rewarded"), user.clone()),
+                    (pool_addr, payout),
+                );
+            }
+        }
+    }
+
+    fn get_boost_bps(tiers: &Vec<LockupTier>, duration: u64) -> u32 {
+        let mut best = 0u32;
+        for tier in tiers.iter() {
+            if duration >= tier.duration_ledgers && tier.boost_bps > best {
+                best = tier.boost_bps;
+            }
+        }
+        best
+    }
+
+    fn apply_boost(amount: i128, boost_bps: u32) -> i128 {
+        amount + (amount * boost_bps as i128) / 10_000
+    }
+
+    fn only_admin(env: &Env) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+    }
+
+    fn not_paused(env: &Env) {
+        let paused: bool = env.storage().instance().get(&PAUSED).unwrap_or(false);
+        if paused {
+            panic!("contract is paused");
+        }
+    }
+}


### PR DESCRIPTION
closes #210 
closes #211 

PR Description:

  ## Summary

  - Implements a full on-chain governance contract for protocol-level upgrade
    proposals, community voting, delegation, timelock execution, and quorum/threshold enforcement
  - Implements an advanced staking and yield farming contract supporting multiple
    reward tokens, tiered lockup boosts, auto-compounding, and emergency withdrawal procedures

  ## Changes

  ### Governance Contract (`contracts/governance`)
  - Proposal lifecycle: `Pending → Active → Succeeded/Defeated → Queued → Executed/Expired/Cancelled`
  - Configurable voting delay, voting period, and timelock delay (ledger-based)
  - Quorum enforcement via `quorum_bps` against total token supply
  - Majority threshold via `threshold_bps` on for/against votes
  - Vote delegation — voting power resolves through delegate chain
  - `cast_vote` and `cast_vote_with_reason` with duplicate-vote protection
  - `queue` and `execute` with timelock enforcement and grace period expiry
  - Proposal creation gated by `proposal_threshold` voting power

  ### Staking & Yield Farming Contract (`contracts/staking`)
  - Flexible lockup tiers with configurable durations and reward boost multipliers (`boost_bps`)
  - Boosted stake weight used across all reward math for fair distribution
  - Multi-reward-token support — independent `RewardPool` per token, all updated atomically
  - Per-ledger reward rate accumulation using `reward_per_token_stored` pattern
  - `compound` — re-stakes accrued rewards back into principal (staking token pools only), with compound fee        
  - `emergency_withdraw` — exits locked position immediately, forfeits all pending rewards, applies penalty fee to  
  fee recipient
  - Contract pause mechanism for emergency stops
  - Admin controls: add/top-up reward pools, update config, update lockup tiers, transfer admin
  