### PR TITLE
feat(tenant): implement tenant provisioning service

### DIFF
--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -29,6 +29,10 @@ model User {
   roles              Role[]  @default([USER])
   hashedRefreshToken String? @map("hashed_refresh_token")
 
+  // Tenant relation (optional — null for platform-level users)
+  tenantId String? @map("tenant_id")
+  tenant   Tenant? @relation(fields: [tenantId], references: [id])
+
   // Relations
   createdProjects      Project[]            @relation("ProjectCreator")
   contributions        Contribution[]
@@ -264,6 +268,63 @@ enum Role {
   TENANT_ADMIN
   USER
   VIEWER
+}
+
+enum TenantStatus {
+  ACTIVE
+  SUSPENDED
+  DELETED
+}
+
+enum TenantPlan {
+  FREE
+  STARTER
+  PROFESSIONAL
+  ENTERPRISE
+}
+
+model Tenant {
+  id        String       @id @default(cuid())
+  name      String       @unique
+  slug      String       @unique
+  status    TenantStatus @default(ACTIVE)
+  plan      TenantPlan   @default(FREE)
+  createdAt DateTime     @default(now()) @map("created_at")
+  updatedAt DateTime     @updatedAt @map("updated_at")
+
+  settings  TenantSettings?
+  users     User[]
+  auditLogs TenantAuditLog[]
+
+  @@map("tenants")
+}
+
+model TenantSettings {
+  id                   String   @id @default(cuid())
+  tenantId             String   @unique @map("tenant_id")
+  tenant               Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  maxUsers             Int      @default(10) @map("max_users")
+  maxProjects          Int      @default(5) @map("max_projects")
+  allowPublicProjects  Boolean  @default(true) @map("allow_public_projects")
+  notificationsEnabled Boolean  @default(true) @map("notifications_enabled")
+  createdAt            DateTime @default(now()) @map("created_at")
+  updatedAt            DateTime @updatedAt @map("updated_at")
+
+  @@map("tenant_settings")
+}
+
+model TenantAuditLog {
+  id        String   @id @default(cuid())
+  tenantId  String   @map("tenant_id")
+  tenant    Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  action    String
+  actorId   String?  @map("actor_id")
+  metadata  Json?
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([tenantId])
+  @@index([action])
+  @@map("tenant_audit_logs")
 }
 
 enum Permission {

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { DatabaseModule } from './database.module';
 import { IndexerModule } from './indexer/indexer.module';
 import { NotificationModule } from './notification/notification.module';
 import { AuthModule } from './auth/auth.module';
+import { TenantModule } from './tenant/tenant.module';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ThrottlerStorageRedisService } from '@nestjs/throttler-storage-redis';
 
@@ -36,6 +37,7 @@ import { ThrottlerStorageRedisService } from '@nestjs/throttler-storage-redis';
     IndexerModule,
     NotificationModule,
     AuthModule,
+    TenantModule,
   ],
   controllers: [AppController, UserController],
   providers: [AppService],

--- a/Backend/src/tenant/dto/create-tenant.dto.ts
+++ b/Backend/src/tenant/dto/create-tenant.dto.ts
@@ -1,0 +1,67 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsBoolean,
+  Min,
+  Max,
+  ValidateNested,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { TenantPlan } from '@prisma/client';
+
+export class TenantSettingsDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  maxUsers?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  maxProjects?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  allowPublicProjects?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  notificationsEnabled?: boolean;
+}
+
+export class CreateTenantDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(2)
+  @MaxLength(64)
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message: 'adminWalletAddress must be a valid Stellar public key',
+  })
+  adminWalletAddress: string;
+
+  @IsOptional()
+  @IsEmail()
+  adminEmail?: string;
+
+  @IsOptional()
+  @IsEnum(TenantPlan)
+  plan?: TenantPlan;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TenantSettingsDto)
+  settings?: TenantSettingsDto;
+}

--- a/Backend/src/tenant/dto/update-tenant-settings.dto.ts
+++ b/Backend/src/tenant/dto/update-tenant-settings.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsInt, IsBoolean, Min, Max } from 'class-validator';
+
+export class UpdateTenantSettingsDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(500)
+  maxUsers?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  maxProjects?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  allowPublicProjects?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  notificationsEnabled?: boolean;
+}

--- a/Backend/src/tenant/tenant.controller.ts
+++ b/Backend/src/tenant/tenant.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { TenantService } from './tenant.service';
+import { CreateTenantDto } from './dto/create-tenant.dto';
+import { UpdateTenantSettingsDto } from './dto/update-tenant-settings.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Role } from '@prisma/client';
+
+@Controller('tenants')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class TenantController {
+  constructor(private readonly tenantService: TenantService) {}
+
+  /**
+   * POST /tenants
+   * Provision a new tenant. SUPER_ADMIN only.
+   */
+  @Post()
+  @Roles(Role.SUPER_ADMIN)
+  @HttpCode(HttpStatus.CREATED)
+  provision(@Body() dto: CreateTenantDto, @CurrentUser() user: any) {
+    return this.tenantService.provision(dto, user?.id);
+  }
+
+  /**
+   * GET /tenants
+   * List all active tenants. SUPER_ADMIN only.
+   */
+  @Get()
+  @Roles(Role.SUPER_ADMIN)
+  findAll() {
+    return this.tenantService.findAll();
+  }
+
+  /**
+   * GET /tenants/:id
+   * Get a single tenant. SUPER_ADMIN or TENANT_ADMIN.
+   */
+  @Get(':id')
+  @Roles(Role.SUPER_ADMIN, Role.TENANT_ADMIN)
+  findOne(@Param('id') id: string) {
+    return this.tenantService.findOne(id);
+  }
+
+  /**
+   * GET /tenants/:id/settings
+   * Get tenant settings. SUPER_ADMIN or TENANT_ADMIN.
+   */
+  @Get(':id/settings')
+  @Roles(Role.SUPER_ADMIN, Role.TENANT_ADMIN)
+  getSettings(@Param('id') id: string) {
+    return this.tenantService.getSettings(id);
+  }
+
+  /**
+   * PATCH /tenants/:id/settings
+   * Update tenant settings. SUPER_ADMIN or TENANT_ADMIN.
+   */
+  @Patch(':id/settings')
+  @Roles(Role.SUPER_ADMIN, Role.TENANT_ADMIN)
+  updateSettings(
+    @Param('id') id: string,
+    @Body() dto: UpdateTenantSettingsDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.tenantService.updateSettings(id, dto, user?.id);
+  }
+
+  /**
+   * GET /tenants/:id/audit-logs
+   * Fetch audit trail for a tenant. SUPER_ADMIN only.
+   */
+  @Get(':id/audit-logs')
+  @Roles(Role.SUPER_ADMIN)
+  getAuditLogs(@Param('id') id: string) {
+    return this.tenantService.getAuditLogs(id);
+  }
+}

--- a/Backend/src/tenant/tenant.module.ts
+++ b/Backend/src/tenant/tenant.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TenantService } from './tenant.service';
+import { TenantController } from './tenant.controller';
+import { DatabaseModule } from '../database.module';
+import { NotificationModule } from '../notification/notification.module';
+
+@Module({
+  imports: [DatabaseModule, NotificationModule],
+  controllers: [TenantController],
+  providers: [TenantService],
+  exports: [TenantService],
+})
+export class TenantModule {}

--- a/Backend/src/tenant/tenant.service.ts
+++ b/Backend/src/tenant/tenant.service.ts
@@ -1,0 +1,195 @@
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+  Logger,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { NotificationService } from '../notification/services/notification.service';
+import { CreateTenantDto } from './dto/create-tenant.dto';
+import { UpdateTenantSettingsDto } from './dto/update-tenant-settings.dto';
+import { TenantPlan, NotificationType } from '@prisma/client';
+
+const PLAN_DEFAULTS: Record<TenantPlan, { maxUsers: number; maxProjects: number }> = {
+  FREE:         { maxUsers: 10,  maxProjects: 5   },
+  STARTER:      { maxUsers: 50,  maxProjects: 20  },
+  PROFESSIONAL: { maxUsers: 200, maxProjects: 100 },
+  ENTERPRISE:   { maxUsers: 500, maxProjects: 500 },
+};
+
+@Injectable()
+export class TenantService {
+  private readonly logger = new Logger(TenantService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  async provision(dto: CreateTenantDto, actorId?: string) {
+    const slug = this.toSlug(dto.name);
+    const plan = dto.plan ?? TenantPlan.FREE;
+    const planDefaults = PLAN_DEFAULTS[plan];
+
+    // Uniqueness guard
+    const existing = await this.prisma.tenant.findFirst({
+      where: { OR: [{ name: dto.name }, { slug }] },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `A tenant with name "${dto.name}" already exists`,
+      );
+    }
+
+    const existingAdmin = await this.prisma.user.findUnique({
+      where: { walletAddress: dto.adminWalletAddress },
+    });
+    if (existingAdmin) {
+      throw new ConflictException(
+        `Wallet address "${dto.adminWalletAddress}" is already registered`,
+      );
+    }
+
+    // Atomic provisioning inside a transaction
+    const { tenant, adminUser } = await this.prisma.$transaction(async (tx) => {
+      const tenant = await tx.tenant.create({
+        data: {
+          name: dto.name,
+          slug,
+          plan,
+          status: 'ACTIVE',
+        },
+      });
+
+      await tx.tenantSettings.create({
+        data: {
+          tenantId: tenant.id,
+          maxUsers:            dto.settings?.maxUsers            ?? planDefaults.maxUsers,
+          maxProjects:         dto.settings?.maxProjects         ?? planDefaults.maxProjects,
+          allowPublicProjects: dto.settings?.allowPublicProjects ?? true,
+          notificationsEnabled: dto.settings?.notificationsEnabled ?? true,
+        },
+      });
+
+      const adminUser = await tx.user.create({
+        data: {
+          walletAddress: dto.adminWalletAddress,
+          email:         dto.adminEmail,
+          roles:         ['TENANT_ADMIN'],
+          tenantId:      tenant.id,
+        },
+      });
+
+      await tx.tenantAuditLog.create({
+        data: {
+          tenantId: tenant.id,
+          action:   'TENANT_PROVISIONED',
+          actorId:  actorId ?? null,
+          metadata: {
+            plan,
+            adminWalletAddress: dto.adminWalletAddress,
+            slug,
+          },
+        },
+      });
+
+      return { tenant, adminUser };
+    });
+
+    // Dispatch welcome notification — non-blocking
+    if (dto.adminEmail) {
+      this.dispatchWelcomeNotification(adminUser.id, dto.name).catch((err) =>
+        this.logger.error(`Welcome notification failed for tenant ${tenant.id}: ${err.message}`),
+      );
+    }
+
+    this.logger.log(`Tenant provisioned: ${tenant.id} (${tenant.slug})`);
+
+    return {
+      tenant: {
+        id:        tenant.id,
+        name:      tenant.name,
+        slug:      tenant.slug,
+        plan:      tenant.plan,
+        status:    tenant.status,
+        createdAt: tenant.createdAt,
+      },
+      adminUser: {
+        id:            adminUser.id,
+        walletAddress: adminUser.walletAddress,
+        roles:         adminUser.roles,
+      },
+    };
+  }
+
+  async findAll() {
+    return this.prisma.tenant.findMany({
+      where: { status: { not: 'DELETED' } },
+      include: { settings: true, _count: { select: { users: true } } },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findOne(id: string) {
+    const tenant = await this.prisma.tenant.findUnique({
+      where: { id },
+      include: { settings: true, _count: { select: { users: true, auditLogs: true } } },
+    });
+    if (!tenant) throw new NotFoundException(`Tenant ${id} not found`);
+    return tenant;
+  }
+
+  async getSettings(tenantId: string) {
+    const settings = await this.prisma.tenantSettings.findUnique({
+      where: { tenantId },
+    });
+    if (!settings) throw new NotFoundException(`Settings for tenant ${tenantId} not found`);
+    return settings;
+  }
+
+  async updateSettings(tenantId: string, dto: UpdateTenantSettingsDto, actorId?: string) {
+    await this.findOne(tenantId);
+
+    const updated = await this.prisma.tenantSettings.update({
+      where: { tenantId },
+      data: dto,
+    });
+
+    await this.prisma.tenantAuditLog.create({
+      data: {
+        tenantId,
+        action:  'SETTINGS_UPDATED',
+        actorId: actorId ?? null,
+        metadata: dto as object,
+      },
+    });
+
+    return updated;
+  }
+
+  async getAuditLogs(tenantId: string) {
+    await this.findOne(tenantId);
+    return this.prisma.tenantAuditLog.findMany({
+      where: { tenantId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  private toSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
+  private async dispatchWelcomeNotification(userId: string, tenantName: string) {
+    await this.notificationService.notify(
+      userId,
+      NotificationType.SYSTEM,
+      'Welcome to Stellara',
+      `Your tenant "${tenantName}" has been successfully provisioned. You can now log in using your wallet address.`,
+      { event: 'TENANT_PROVISIONED', tenantName },
+    );
+  }
+}


### PR DESCRIPTION
- Add Tenant, TenantSettings, and TenantAuditLog Prisma models with TenantStatus and TenantPlan enums; link User to optional tenant
- TenantService.provision() runs atomically: creates tenant record, default settings (plan-tiered limits), TENANT_ADMIN user, and an audit log entry in a single transaction, then dispatches a welcome notification (non-blocking)
- REST API: POST /tenants (SUPER_ADMIN), GET /tenants, GET /tenants/:id, GET /tenants/:id/settings, PATCH /tenants/:id/settings, GET /tenants/:id/audit-logs
- All endpoints protected by JwtAuthGuard + RolesGuard; writes append to TenantAuditLog for full traceability
- Register TenantModule in AppModule

Closes #266