### PR TITLE
fix(backend): wallet auth, DB pool config, reputation audit trail, input sanitization (#607-#610)

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,6 +1,8 @@
 # Database Configuration
-# Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE_NAME?schema=public
-DATABASE_URL=postgresql://postgres:password@localhost:5432/novafund?schema=public
+# connection_limit: max pool size — recommended: (CPU_cores * 2) + 1, e.g. 10 for a 4-core host
+# pool_timeout:     seconds to wait for a free connection before erroring (default: 10)
+# connection_timeout: seconds to wait when opening a new connection (default: 5)
+DATABASE_URL=postgresql://postgres:password@localhost:5432/novafund?schema=public&connection_limit=10&pool_timeout=10&connection_timeout=5
 
 # Redis Configuration
 REDIS_HOST=localhost

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -22,6 +22,8 @@ import { AppLogger } from './common/logger/app.logger';
 import { AppCacheModule } from './cache/cache.module';
 import { V1Module } from './modules/v1/v1.module';
 import { V2Module } from './modules/v2/v2.module';
+import { NonceModule } from './nonce/nonce.module';
+import { SanitizationMiddleware } from './common/middleware/sanitization.middleware';
 
 @Module({
   imports: [
@@ -55,6 +57,7 @@ import { V2Module } from './modules/v2/v2.module';
     AppCacheModule,
     V1Module,
     V2Module,
+    NonceModule,
   ],
   controllers: [AppController],
   providers: [AppService, AppLogger, ApiVersionMiddleware, TimeoutMiddleware],
@@ -62,7 +65,7 @@ import { V2Module } from './modules/v2/v2.module';
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
     consumer
-      .apply(CorrelationIdMiddleware, LoggingMiddleware, ApiVersionMiddleware, TimeoutMiddleware)
+      .apply(CorrelationIdMiddleware, LoggingMiddleware, ApiVersionMiddleware, TimeoutMiddleware, SanitizationMiddleware)
       .forRoutes('*');
   }
 }

--- a/Backend/src/auth/guards/wallet-auth.guard.ts
+++ b/Backend/src/auth/guards/wallet-auth.guard.ts
@@ -1,0 +1,30 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { NonceService } from '../../nonce/nonce.service';
+
+/**
+ * Guard that enforces wallet ownership via challenge-response signature verification.
+ * Expects headers: x-wallet-address and x-wallet-signature (base64-encoded).
+ */
+@Injectable()
+export class WalletAuthGuard implements CanActivate {
+  constructor(private readonly nonceService: NonceService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const walletAddress = req.headers['x-wallet-address'] as string;
+    const signature = req.headers['x-wallet-signature'] as string;
+
+    if (!walletAddress || !signature) {
+      throw new UnauthorizedException('Missing x-wallet-address or x-wallet-signature header.');
+    }
+
+    this.nonceService.verifySignature(walletAddress, signature);
+    req.walletAddress = walletAddress;
+    return true;
+  }
+}

--- a/Backend/src/common/middleware/sanitization.middleware.ts
+++ b/Backend/src/common/middleware/sanitization.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { sanitizeUnknown } from '../utils/sanitize.util';
+
+@Injectable()
+export class SanitizationMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction): void {
+    if (req.body && typeof req.body === 'object') {
+      req.body = sanitizeUnknown(req.body);
+    }
+    next();
+  }
+}

--- a/Backend/src/nonce/nonce.controller.ts
+++ b/Backend/src/nonce/nonce.controller.ts
@@ -1,6 +1,20 @@
-import { Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
 import { NonceService } from './nonce.service';
+
+class RequestNonceDto {
+  @IsString()
+  walletAddress: string;
+}
+
+class VerifySignatureDto {
+  @IsString()
+  walletAddress: string;
+
+  @IsString()
+  signature: string;
+}
 
 @ApiTags('Auth')
 @Controller('nonce')
@@ -8,9 +22,17 @@ export class NonceController {
   constructor(private readonly nonceService: NonceService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Generate nonce for wallet-based auth flows' })
+  @ApiOperation({ summary: 'Generate nonce for wallet-based auth' })
   @ApiResponse({ status: 201, description: 'Nonce generated' })
-  async getNonce(): Promise<string> {
-    return this.nonceService.generateNonce();
+  getNonce(@Body() dto: RequestNonceDto): { nonce: string } {
+    return { nonce: this.nonceService.generateNonce(dto.walletAddress) };
+  }
+
+  @Post('verify')
+  @ApiOperation({ summary: 'Verify wallet signature against issued nonce' })
+  @ApiResponse({ status: 201, description: 'Signature valid' })
+  verify(@Body() dto: VerifySignatureDto): { verified: boolean } {
+    this.nonceService.verifySignature(dto.walletAddress, dto.signature);
+    return { verified: true };
   }
 }

--- a/Backend/src/nonce/nonce.module.ts
+++ b/Backend/src/nonce/nonce.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { NonceController } from './nonce.controller';
+import { NonceService } from './nonce.service';
+
+@Module({
+  controllers: [NonceController],
+  providers: [NonceService],
+  exports: [NonceService],
+})
+export class NonceModule {}

--- a/Backend/src/nonce/nonce.service.ts
+++ b/Backend/src/nonce/nonce.service.ts
@@ -1,10 +1,51 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { randomBytes } from 'crypto';
+import { Keypair } from '@stellar/stellar-base';
+
+const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface NonceEntry {
+  nonce: string;
+  expiresAt: number;
+}
 
 @Injectable()
 export class NonceService {
-  generateNonce(): string {
+  private readonly store = new Map<string, NonceEntry>();
+
+  generateNonce(walletAddress: string): string {
     const nonce = randomBytes(16).toString('hex');
+    this.store.set(walletAddress, { nonce, expiresAt: Date.now() + NONCE_TTL_MS });
     return nonce;
+  }
+
+  verifySignature(walletAddress: string, signature: string): void {
+    const entry = this.store.get(walletAddress);
+
+    if (!entry) {
+      throw new UnauthorizedException('No nonce found for this wallet. Request a new one.');
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(walletAddress);
+      throw new UnauthorizedException('Nonce expired. Request a new one.');
+    }
+
+    try {
+      const keypair = Keypair.fromPublicKey(walletAddress);
+      const messageBytes = Buffer.from(entry.nonce, 'utf8');
+      const signatureBytes = Buffer.from(signature, 'base64');
+      const valid = keypair.verify(messageBytes, signatureBytes);
+
+      if (!valid) {
+        throw new UnauthorizedException('Invalid signature.');
+      }
+    } catch (e) {
+      if (e instanceof UnauthorizedException) throw e;
+      throw new UnauthorizedException('Signature verification failed.');
+    }
+
+    // Consume nonce — prevents replay attacks
+    this.store.delete(walletAddress);
   }
 }

--- a/Backend/src/reputation/reputation.service.ts
+++ b/Backend/src/reputation/reputation.service.ts
@@ -36,11 +36,27 @@ export class ReputationService {
    * This is a simpler, rule-based score for creators.
    */
   async updateTrustScore(userId: string): Promise<number> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { trustScore: true },
+    });
+
+    const previousScore = user?.trustScore ?? 0;
     const score = await calculateTrustScore(this.prisma, userId);
+
     await this.prisma.user.update({
       where: { id: userId },
       data: { trustScore: score },
     });
+
+    await this.prisma.reputationHistory.create({
+      data: {
+        userId,
+        scoreChange: score - previousScore,
+        reason: 'TRUST_SCORE_RECALCULATION',
+      },
+    });
+
     return score;
   }
 


### PR DESCRIPTION
## Summary

Resolves four backend issues in a single focused PR.

---

### #607 — Wallet Signature Verification
- `NonceService.generateNonce(walletAddress)`: stores a per-wallet nonce with a 5-minute TTL
- `NonceService.verifySignature()`: verifies the Stellar Ed25519 signature via `@stellar/stellar-base` `Keypair.verify()`, then consumes the nonce (replay prevention)
- `WalletAuthGuard`: reads `x-wallet-address` / `x-wallet-signature` headers and delegates to `NonceService`
- `NonceController`: `POST /nonce` (issue nonce) and `POST /nonce/verify` (verify signature)
- `NonceModule` registered in `AppModule`

### #608 — DB Connection Pool Configuration
- `.env.example` `DATABASE_URL` now includes `connection_limit=10`, `pool_timeout=10`, `connection_timeout=5` with inline sizing guidance

### #609 — Reputation Audit Trail
- `updateTrustScore()` now fetches the user's current score before recalculating, then writes a `ReputationHistory` record with `scoreChange` and `reason: 'TRUST_SCORE_RECALCULATION'`

### #610 — Input Sanitization Middleware
- `SanitizationMiddleware` strips HTML tags and `javascript:` protocols from all request bodies using the existing `sanitizeUnknown` util
- Applied globally in `AppModule` middleware chain

Closes #607
Closes #608
Closes #609
Closes #610