### PR TITLE
feat: RBAC, rate limiting, JWT refresh & session management

### DIFF
--- a/Backend/prisma/migrations/20260424160900_add_auth_rbac_sessions/migration.sql
+++ b/Backend/prisma/migrations/20260424160900_add_auth_rbac_sessions/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable: roles, permissions, user_roles, refresh_tokens, sessions (#705, #706, #707, #708)
+
+CREATE TABLE "roles" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "roles_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "permissions" (
+    "id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    CONSTRAINT "permissions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "_PermissionToRole" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+CREATE TABLE "user_roles" (
+    "user_id" TEXT NOT NULL,
+    "role_id" TEXT NOT NULL,
+    "assigned_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "user_roles_pkey" PRIMARY KEY ("user_id","role_id")
+);
+
+CREATE TABLE "refresh_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "revoked_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "sessions" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "last_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "terminated_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "roles_name_key" ON "roles"("name");
+CREATE UNIQUE INDEX "permissions_action_key" ON "permissions"("action");
+CREATE UNIQUE INDEX "_PermissionToRole_AB_unique" ON "_PermissionToRole"("A", "B");
+CREATE INDEX "_PermissionToRole_B_index" ON "_PermissionToRole"("B");
+CREATE UNIQUE INDEX "refresh_tokens_token_key" ON "refresh_tokens"("token");
+CREATE INDEX "refresh_tokens_user_id_idx" ON "refresh_tokens"("user_id");
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+CREATE INDEX "sessions_user_id_idx" ON "sessions"("user_id");
+
+ALTER TABLE "user_roles" ADD CONSTRAINT "user_roles_role_id_fkey" FOREIGN KEY ("role_id") REFERENCES "roles"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "_PermissionToRole" ADD CONSTRAINT "_PermissionToRole_A_fkey" FOREIGN KEY ("A") REFERENCES "permissions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "_PermissionToRole" ADD CONSTRAINT "_PermissionToRole_B_fkey" FOREIGN KEY ("B") REFERENCES "roles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -44,6 +44,9 @@ model User {
   disputeComments      DisputeComment[]
   resolvedDisputes     DisputeResolution[] @relation("ResolutionModerator")
 
+  // Auth Relations
+  roles                UserRole[]
+
   @@map("users")
 }
 
@@ -1532,4 +1535,61 @@ model FeatureFlag {
   updatedAt   DateTime @updatedAt @map("updated_at")
 
   @@map("feature_flags")
+}
+
+// ─── Auth: RBAC, JWT Refresh, Session (#705, #707, #708) ───────────────────
+
+model Role {
+  id          String       @id @default(cuid())
+  name        String       @unique
+  permissions Permission[]
+  users       UserRole[]
+  createdAt   DateTime     @default(now()) @map("created_at")
+
+  @@map("roles")
+}
+
+model Permission {
+  id     String @id @default(cuid())
+  action String @unique // e.g. "user:read", "admin:write"
+  roles  Role[]
+
+  @@map("permissions")
+}
+
+model UserRole {
+  userId    String   @map("user_id")
+  roleId    String   @map("role_id")
+  role      Role     @relation(fields: [roleId], references: [id])
+  assignedAt DateTime @default(now()) @map("assigned_at")
+
+  @@id([userId, roleId])
+  @@map("user_roles")
+}
+
+model RefreshToken {
+  id        String   @id @default(cuid())
+  userId    String   @map("user_id")
+  token     String   @unique
+  expiresAt DateTime @map("expires_at")
+  revokedAt DateTime? @map("revoked_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@map("refresh_tokens")
+}
+
+model Session {
+  id         String    @id @default(cuid())
+  userId     String    @map("user_id")
+  token      String    @unique
+  ipAddress  String?   @map("ip_address")
+  userAgent  String?   @map("user_agent")
+  lastSeenAt DateTime  @default(now()) @map("last_seen_at")
+  expiresAt  DateTime  @map("expires_at")
+  terminatedAt DateTime? @map("terminated_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@map("sessions")
 }

--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { IdempotencyModule } from './idempotency/idempotency.module';
 import { BulkModule } from './bulk/bulk.module';
 import { FeatureFlagsModule } from './feature-flags/feature-flags.module';
 import { StellaraGraphQLModule } from './graphql/graphql.module';
+import { AuthModule } from './auth/auth.module';
 
 // Middleware & Common
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
@@ -84,6 +85,7 @@ import { AppLogger } from './common/logger/app.logger';
     BulkModule,
     FeatureFlagsModule,
     StellaraGraphQLModule,
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService, AppLogger, ApiVersionMiddleware, TimeoutMiddleware],

--- a/Backend/src/auth/auth.module.ts
+++ b/Backend/src/auth/auth.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { RbacService } from './rbac.service';
+import { RefreshTokenService } from './refresh-token.service';
+import { SessionService } from './session.service';
+import { RbacGuard } from './guards/rbac.guard';
+import { RateLimitGuard } from './guards/rate-limit.guard';
+import { RbacController } from './controllers/rbac.controller';
+import { TokenController } from './controllers/token.controller';
+import { SessionController } from './controllers/session.controller';
+
+@Module({
+  providers: [PrismaService, RbacService, RefreshTokenService, SessionService, RbacGuard, RateLimitGuard],
+  controllers: [RbacController, TokenController, SessionController],
+  exports: [RbacService, RefreshTokenService, SessionService, RbacGuard, RateLimitGuard],
+})
+export class AuthModule {}

--- a/Backend/src/auth/controllers/rbac.controller.ts
+++ b/Backend/src/auth/controllers/rbac.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Post, Delete, Get, Body, Param, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { RbacService } from '../rbac.service';
+
+@ApiTags('rbac')
+@Controller('auth/rbac')
+export class RbacController {
+  constructor(private readonly rbac: RbacService) {}
+
+  @Post('roles')
+  @ApiOperation({ summary: 'Create role' })
+  createRole(@Body('name') name: string) {
+    return this.rbac.createRole(name);
+  }
+
+  @Post('permissions')
+  @ApiOperation({ summary: 'Create permission' })
+  createPermission(@Body('action') action: string) {
+    return this.rbac.createPermission(action);
+  }
+
+  @Get('roles')
+  @ApiOperation({ summary: 'List all roles with permissions' })
+  listRoles() {
+    return this.rbac.listRoles();
+  }
+
+  @Post('roles/:role/permissions/:action')
+  @ApiOperation({ summary: 'Attach permission to role' })
+  attachPermission(@Param('role') role: string, @Param('action') action: string) {
+    return this.rbac.attachPermissionToRole(role, action);
+  }
+
+  @Post('users/:userId/roles/:role')
+  @ApiOperation({ summary: 'Assign role to user' })
+  assignRole(@Param('userId') userId: string, @Param('role') role: string) {
+    return this.rbac.assignRoleToUser(userId, role);
+  }
+
+  @Delete('users/:userId/roles/:role')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove role from user' })
+  removeRole(@Param('userId') userId: string, @Param('role') role: string) {
+    return this.rbac.removeRoleFromUser(userId, role);
+  }
+
+  @Get('users/:userId/permissions')
+  @ApiOperation({ summary: 'Get user permissions' })
+  getUserPermissions(@Param('userId') userId: string) {
+    return this.rbac.getUserPermissions(userId);
+  }
+}

--- a/Backend/src/auth/controllers/session.controller.ts
+++ b/Backend/src/auth/controllers/session.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Delete, Param, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { SessionService } from '../session.service';
+
+@ApiTags('auth')
+@Controller('auth/sessions')
+export class SessionController {
+  constructor(private readonly sessions: SessionService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List active sessions for current user' })
+  list(@Req() req: any) {
+    return this.sessions.listSessions(req.user?.id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Terminate a specific session' })
+  terminate(@Param('id') id: string, @Req() req: any) {
+    return this.sessions.terminateSession(id, req.user?.id);
+  }
+
+  @Delete()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Terminate all sessions (logout everywhere)' })
+  terminateAll(@Req() req: any) {
+    return this.sessions.terminateAllSessions(req.user?.id);
+  }
+}

--- a/Backend/src/auth/controllers/token.controller.ts
+++ b/Backend/src/auth/controllers/token.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Post, Body, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { RefreshTokenService } from '../refresh-token.service';
+
+@ApiTags('auth')
+@Controller('auth')
+export class TokenController {
+  constructor(private readonly tokenService: RefreshTokenService) {}
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Rotate refresh token and get new access token' })
+  refresh(@Body('refreshToken') refreshToken: string) {
+    return this.tokenService.rotate(refreshToken);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke all tokens (logout)' })
+  logout(@Req() req: any) {
+    const userId = req.user?.id;
+    if (userId) return this.tokenService.revokeAll(userId);
+  }
+}

--- a/Backend/src/auth/decorators/roles.decorator.ts
+++ b/Backend/src/auth/decorators/roles.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);
+
+export const PERMISSIONS_KEY = 'permissions';
+export const RequirePermissions = (...permissions: string[]) =>
+  SetMetadata(PERMISSIONS_KEY, permissions);

--- a/Backend/src/auth/guards/rate-limit.guard.ts
+++ b/Backend/src/auth/guards/rate-limit.guard.ts
@@ -1,0 +1,70 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+export const RATE_LIMIT_KEY = 'rateLimit';
+export const RateLimit = (limit: number, ttlSeconds: number) =>
+  Reflect.metadata(RATE_LIMIT_KEY, { limit, ttlSeconds });
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  private readonly store = new Map<string, RateLimitEntry>();
+
+  // Default: 100 req / 60s per user+IP
+  private readonly defaultLimit = 100;
+  private readonly defaultTtl = 60_000;
+
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const meta = this.reflector.getAllAndOverride<{ limit: number; ttlSeconds: number }>(
+      RATE_LIMIT_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    const limit = meta?.limit ?? this.defaultLimit;
+    const ttl = (meta?.ttlSeconds ?? 60) * 1000;
+
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+    const ip = req.ip ?? req.connection?.remoteAddress ?? 'unknown';
+    const userId = req.user?.id ?? 'anon';
+    const key = `${userId}:${ip}:${req.route?.path ?? req.path}`;
+
+    const now = Date.now();
+    let entry = this.store.get(key);
+
+    if (!entry || now > entry.resetAt) {
+      entry = { count: 0, resetAt: now + ttl };
+      this.store.set(key, entry);
+    }
+
+    entry.count++;
+    const remaining = Math.max(0, limit - entry.count);
+    const resetSec = Math.ceil((entry.resetAt - now) / 1000);
+
+    res.setHeader('X-RateLimit-Limit', limit);
+    res.setHeader('X-RateLimit-Remaining', remaining);
+    res.setHeader('X-RateLimit-Reset', resetSec);
+
+    if (entry.count > limit) {
+      res.setHeader('Retry-After', resetSec);
+      throw new HttpException(
+        { message: 'Too Many Requests', retryAfter: resetSec },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return true;
+  }
+}

--- a/Backend/src/auth/guards/rbac.guard.ts
+++ b/Backend/src/auth/guards/rbac.guard.ts
@@ -1,0 +1,42 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY, PERMISSIONS_KEY } from '../decorators/roles.decorator';
+import { RbacService } from '../rbac.service';
+
+@Injectable()
+export class RbacGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly rbac: RbacService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    const requiredPerms = this.reflector.getAllAndOverride<string[]>(PERMISSIONS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles?.length && !requiredPerms?.length) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+    if (!user?.id) throw new ForbiddenException('Unauthorized');
+
+    if (requiredRoles?.length) {
+      const userRoles = await this.rbac.getUserRoles(user.id);
+      const hasRole = requiredRoles.some((r) => userRoles.includes(r));
+      if (!hasRole) throw new ForbiddenException('Insufficient role');
+    }
+
+    if (requiredPerms?.length) {
+      const userPerms = await this.rbac.getUserPermissions(user.id);
+      const hasPerm = requiredPerms.every((p) => userPerms.includes(p));
+      if (!hasPerm) throw new ForbiddenException('Insufficient permissions');
+    }
+
+    return true;
+  }
+}

--- a/Backend/src/auth/rbac.service.ts
+++ b/Backend/src/auth/rbac.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { PrismaService } from '../../../src/prisma.service';
+
+@Injectable()
+export class RbacService {
+  private readonly logger = new Logger(RbacService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createRole(name: string) {
+    return this.prisma.role.create({ data: { name } });
+  }
+
+  async createPermission(action: string) {
+    return this.prisma.permission.create({ data: { action } });
+  }
+
+  async assignRoleToUser(userId: string, roleName: string) {
+    const role = await this.prisma.role.findUnique({ where: { name: roleName } });
+    if (!role) throw new NotFoundException(`Role ${roleName} not found`);
+    const result = await this.prisma.userRole.upsert({
+      where: { userId_roleId: { userId, roleId: role.id } },
+      create: { userId, roleId: role.id },
+      update: {},
+    });
+    this.logger.log(`Role ${roleName} assigned to user ${userId}`);
+    return result;
+  }
+
+  async attachPermissionToRole(roleName: string, action: string) {
+    const [role, permission] = await Promise.all([
+      this.prisma.role.findUnique({ where: { name: roleName } }),
+      this.prisma.permission.findUnique({ where: { action } }),
+    ]);
+    if (!role) throw new NotFoundException(`Role ${roleName} not found`);
+    if (!permission) throw new NotFoundException(`Permission ${action} not found`);
+    const result = await this.prisma.role.update({
+      where: { id: role.id },
+      data: { permissions: { connect: { id: permission.id } } },
+    });
+    this.logger.log(`Permission ${action} attached to role ${roleName}`);
+    return result;
+  }
+
+  async getUserPermissions(userId: string): Promise<string[]> {
+    const userRoles = await this.prisma.userRole.findMany({
+      where: { userId },
+      include: { role: { include: { permissions: true } } },
+    });
+    const permissions = new Set<string>();
+    for (const ur of userRoles) {
+      for (const p of ur.role.permissions) permissions.add(p.action);
+    }
+    return [...permissions];
+  }
+
+  async getUserRoles(userId: string): Promise<string[]> {
+    const userRoles = await this.prisma.userRole.findMany({
+      where: { userId },
+      include: { role: true },
+    });
+    return userRoles.map((ur) => ur.role.name);
+  }
+
+  async listRoles() {
+    return this.prisma.role.findMany({ include: { permissions: true } });
+  }
+
+  async removeRoleFromUser(userId: string, roleName: string) {
+    const role = await this.prisma.role.findUnique({ where: { name: roleName } });
+    if (!role) throw new NotFoundException(`Role ${roleName} not found`);
+    await this.prisma.userRole.delete({
+      where: { userId_roleId: { userId, roleId: role.id } },
+    });
+    this.logger.log(`Role ${roleName} removed from user ${userId}`);
+  }
+}

--- a/Backend/src/auth/refresh-token.service.ts
+++ b/Backend/src/auth/refresh-token.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { randomBytes, createHmac } from 'crypto';
+import { PrismaService } from '../../prisma.service';
+
+const REFRESH_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const ACCESS_TTL_MS = 15 * 60 * 1000; // 15 min
+
+@Injectable()
+export class RefreshTokenService {
+  private readonly logger = new Logger(RefreshTokenService.name);
+  // In-memory access token store: token -> { userId, expiresAt }
+  private readonly accessTokens = new Map<string, { userId: string; expiresAt: number }>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Issue a new access + refresh token pair */
+  async issueTokens(userId: string): Promise<{ accessToken: string; refreshToken: string }> {
+    const accessToken = this.generateToken();
+    const refreshToken = this.generateToken();
+
+    this.accessTokens.set(accessToken, { userId, expiresAt: Date.now() + ACCESS_TTL_MS });
+
+    await this.prisma.refreshToken.create({
+      data: {
+        userId,
+        token: this.hash(refreshToken),
+        expiresAt: new Date(Date.now() + REFRESH_TTL_MS),
+      },
+    });
+
+    return { accessToken, refreshToken };
+  }
+
+  /** Rotate: revoke old refresh token, issue new pair */
+  async rotate(refreshToken: string): Promise<{ accessToken: string; refreshToken: string }> {
+    const hashed = this.hash(refreshToken);
+    const record = await this.prisma.refreshToken.findUnique({ where: { token: hashed } });
+
+    if (!record || record.revokedAt || record.expiresAt < new Date()) {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    // Revoke old token
+    await this.prisma.refreshToken.update({
+      where: { id: record.id },
+      data: { revokedAt: new Date() },
+    });
+
+    return this.issueTokens(record.userId);
+  }
+
+  /** Revoke all refresh tokens for a user (logout) */
+  async revokeAll(userId: string): Promise<void> {
+    await this.prisma.refreshToken.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+    // Purge in-memory access tokens for user
+    for (const [token, data] of this.accessTokens) {
+      if (data.userId === userId) this.accessTokens.delete(token);
+    }
+  }
+
+  /** Validate access token, returns userId */
+  validateAccessToken(token: string): string {
+    const entry = this.accessTokens.get(token);
+    if (!entry || Date.now() > entry.expiresAt) {
+      this.accessTokens.delete(token);
+      throw new UnauthorizedException('Invalid or expired access token');
+    }
+    return entry.userId;
+  }
+
+  /** Cleanup expired tokens daily */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async cleanupExpired(): Promise<void> {
+    const { count } = await this.prisma.refreshToken.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    this.logger.log(`Cleaned up ${count} expired refresh tokens`);
+  }
+
+  private generateToken(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  private hash(token: string): string {
+    return createHmac('sha256', process.env.JWT_SECRET ?? 'stellara-secret').update(token).digest('hex');
+  }
+}

--- a/Backend/src/auth/session.service.ts
+++ b/Backend/src/auth/session.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, UnauthorizedException, ForbiddenException, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { randomBytes } from 'crypto';
+import { PrismaService } from '../../prisma.service';
+
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const MAX_CONCURRENT_SESSIONS = 5;
+
+@Injectable()
+export class SessionService {
+  private readonly logger = new Logger(SessionService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSession(userId: string, ip?: string, userAgent?: string): Promise<string> {
+    const activeSessions = await this.prisma.session.count({
+      where: { userId, terminatedAt: null, expiresAt: { gt: new Date() } },
+    });
+
+    if (activeSessions >= MAX_CONCURRENT_SESSIONS) {
+      // Terminate oldest session
+      const oldest = await this.prisma.session.findFirst({
+        where: { userId, terminatedAt: null },
+        orderBy: { createdAt: 'asc' },
+      });
+      if (oldest) {
+        await this.prisma.session.update({
+          where: { id: oldest.id },
+          data: { terminatedAt: new Date() },
+        });
+      }
+    }
+
+    const token = randomBytes(32).toString('hex');
+    await this.prisma.session.create({
+      data: {
+        userId,
+        token,
+        ipAddress: ip,
+        userAgent,
+        expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+      },
+    });
+
+    return token;
+  }
+
+  async validateSession(token: string): Promise<string> {
+    const session = await this.prisma.session.findUnique({ where: { token } });
+
+    if (!session || session.terminatedAt || session.expiresAt < new Date()) {
+      throw new UnauthorizedException('Session invalid or expired');
+    }
+
+    await this.prisma.session.update({
+      where: { id: session.id },
+      data: { lastSeenAt: new Date() },
+    });
+
+    return session.userId;
+  }
+
+  async listSessions(userId: string) {
+    return this.prisma.session.findMany({
+      where: { userId, terminatedAt: null, expiresAt: { gt: new Date() } },
+      select: { id: true, ipAddress: true, userAgent: true, lastSeenAt: true, createdAt: true },
+      orderBy: { lastSeenAt: 'desc' },
+    });
+  }
+
+  async terminateSession(sessionId: string, requestingUserId: string): Promise<void> {
+    const session = await this.prisma.session.findUnique({ where: { id: sessionId } });
+    if (!session) return;
+    if (session.userId !== requestingUserId) throw new ForbiddenException('Not your session');
+    await this.prisma.session.update({
+      where: { id: sessionId },
+      data: { terminatedAt: new Date() },
+    });
+  }
+
+  async terminateAllSessions(userId: string): Promise<void> {
+    await this.prisma.session.updateMany({
+      where: { userId, terminatedAt: null },
+      data: { terminatedAt: new Date() },
+    });
+  }
+
+  /** Cleanup expired sessions daily */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async cleanupExpired(): Promise<void> {
+    const { count } = await this.prisma.session.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    this.logger.log(`Cleaned up ${count} expired sessions`);
+  }
+}


### PR DESCRIPTION
Closes #705, closes #706, closes #707, closes #708

## Changes
- **#705 RBAC**: `Role`, `Permission`, `UserRole` models + `RbacService`, `RbacGuard`, `@Roles`/`@RequirePermissions` decorators, `/auth/rbac` endpoints with audit logging
- **#706 Rate Limiting**: `RateLimitGuard` with user+IP keying, `X-RateLimit-*` headers, 429 breach handling, per-endpoint `@RateLimit` decorator
- **#707 JWT Refresh**: `RefreshToken` model + `RefreshTokenService` with HMAC-hashed token rotation, revocation, in-memory access tokens, daily cleanup cron; `POST /auth/refresh` & `POST /auth/logout`
- **#708 Sessions**: `Session` model + `SessionService` with concurrent limit (5), activity tracking, timeout, daily cleanup; `GET/DELETE /auth/sessions`
- Migration: `20260424160900_add_auth_rbac_sessions`