### PR TITLE
fix/issue-771-token-interface-consistency

### DIFF
--- a/Contracts/contracts/token/src/libs.rs
+++ b/Contracts/contracts/token/src/libs.rs
@@ -1,30 +1,192 @@
-use soroban_sdk::{contract, contractimpl, Env, Address};
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Address, String};
 
 mod admin;
 mod storage;
 
+/// SEP-41 compliant token contract.
+///
+/// Exposes the full standard interface expected by soroban_sdk::token::Client
+/// across all contracts in the Stellara workspace.
 #[contract]
 pub struct TokenContract;
 
 #[contractimpl]
 impl TokenContract {
 
-    pub fn initialize(env: Env, admin: Address) {
+    // =========================================================================
+    // Initialisation
+    // =========================================================================
+
+    pub fn initialize(env: Env, admin: Address, name: String, symbol: String, decimals: u32) {
         if storage::has_admin(&env) {
             panic!("Already initialized");
         }
         admin.require_auth();
         storage::set_admin(&env, &admin);
+
+        env.storage().instance().set(&symbol_short!("NAME"), &name);
+        env.storage().instance().set(&symbol_short!("SYMBOL"), &symbol);
+        env.storage().instance().set(&symbol_short!("DECIMALS"), &decimals);
     }
+
+    // =========================================================================
+    // Metadata
+    // =========================================================================
+
+    pub fn name(env: Env) -> String {
+        env.storage().instance().get(&symbol_short!("NAME")).expect("Not initialized")
+    }
+
+    pub fn symbol(env: Env) -> String {
+        env.storage().instance().get(&symbol_short!("SYMBOL")).expect("Not initialized")
+    }
+
+    pub fn decimals(env: Env) -> u32 {
+        env.storage().instance().get(&symbol_short!("DECIMALS")).expect("Not initialized")
+    }
+
+    // =========================================================================
+    // Core SEP-41 / ERC-20 interface
+    // =========================================================================
+
+    pub fn total_supply(env: Env) -> i128 {
+        storage::get_total_supply(&env)
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        storage::balance_of(&env, &id)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        let from_balance = storage::balance_of(&env, &from);
+        assert!(from_balance >= amount, "Insufficient balance");
+
+        let to_balance = storage::balance_of(&env, &to);
+
+        storage::set_balance(&env, &from, &(from_balance - amount));
+        storage::set_balance(&env, &to, &(to_balance + amount));
+
+        env.events().publish(
+            (symbol_short!("transfer"), from.clone(), to.clone()),
+            amount,
+        );
+    }
+
+    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+        spender.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        // Consume allowance
+        let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
+        assert!(allowance >= amount, "Allowance exceeded");
+        Self::_set_allowance(&env, &from, &spender, allowance - amount);
+
+        let from_balance = storage::balance_of(&env, &from);
+        assert!(from_balance >= amount, "Insufficient balance");
+        let to_balance = storage::balance_of(&env, &to);
+
+        storage::set_balance(&env, &from, &(from_balance - amount));
+        storage::set_balance(&env, &to, &(to_balance + amount));
+
+        env.events().publish(
+            (symbol_short!("transfer"), from.clone(), to.clone()),
+            amount,
+        );
+    }
+
+    pub fn approve(env: Env, from: Address, spender: Address, amount: i128, _expiration_ledger: u32) {
+        from.require_auth();
+        assert!(amount >= 0, "Amount must be non-negative");
+        Self::_set_allowance(&env, &from, &spender, amount);
+        env.events().publish(
+            (symbol_short!("approve"), from.clone(), spender.clone()),
+            amount,
+        );
+    }
+
+    pub fn allowance(env: Env, from: Address, spender: Address) -> i128 {
+        let key = (symbol_short!("ALLOW"), from, spender);
+        env.storage().temporary().get(&key).unwrap_or(0)
+    }
+
+    // =========================================================================
+    // Mint / Burn (admin-only)
+    // =========================================================================
 
     pub fn mint(env: Env, to: Address, amount: i128) {
         admin::require_admin(&env);
+        assert!(amount > 0, "Amount must be positive");
 
-        // checked arithmetic
         let balance = storage::balance_of(&env, &to);
-        let new_balance = balance.checked_add(amount)
-            .expect("Overflow");
-
+        let new_balance = balance.checked_add(amount).expect("Overflow");
         storage::set_balance(&env, &to, &new_balance);
+
+        let supply = storage::get_total_supply(&env);
+        storage::set_total_supply(&env, &(supply.checked_add(amount).expect("Supply overflow")));
+
+        env.events().publish(
+            (symbol_short!("mint"), to.clone()),
+            amount,
+        );
+    }
+
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        let balance = storage::balance_of(&env, &from);
+        assert!(balance >= amount, "Insufficient balance");
+        storage::set_balance(&env, &from, &(balance - amount));
+
+        let supply = storage::get_total_supply(&env);
+        storage::set_total_supply(&env, &(supply - amount));
+
+        env.events().publish(
+            (symbol_short!("burn"), from.clone()),
+            amount,
+        );
+    }
+
+    pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
+        spender.require_auth();
+        assert!(amount > 0, "Amount must be positive");
+
+        let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
+        assert!(allowance >= amount, "Allowance exceeded");
+        Self::_set_allowance(&env, &from, &spender, allowance - amount);
+
+        let balance = storage::balance_of(&env, &from);
+        assert!(balance >= amount, "Insufficient balance");
+        storage::set_balance(&env, &from, &(balance - amount));
+
+        let supply = storage::get_total_supply(&env);
+        storage::set_total_supply(&env, &(supply - amount));
+
+        env.events().publish(
+            (symbol_short!("burn"), from.clone()),
+            amount,
+        );
+    }
+
+    // =========================================================================
+    // Admin helpers
+    // =========================================================================
+
+    pub fn set_admin(env: Env, new_admin: Address) {
+        admin::require_admin(&env);
+        new_admin.require_auth();
+        storage::set_admin(&env, &new_admin);
+    }
+
+    // =========================================================================
+    // Internal helpers
+    // =========================================================================
+
+    fn _set_allowance(env: &Env, from: &Address, spender: &Address, amount: i128) {
+        let key = (symbol_short!("ALLOW"), from.clone(), spender.clone());
+        env.storage().temporary().set(&key, &amount);
     }
 }

--- a/Contracts/contracts/token/src/storage.rs
+++ b/Contracts/contracts/token/src/storage.rs
@@ -1,14 +1,48 @@
-use soroban_sdk::{Env, Address, Symbol};
+use soroban_sdk::{contracttype, Env, Address};
 
-const ADMIN_KEY: Symbol = Symbol::short("ADMIN");
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Balance(Address),
+    TotalSupply,
+}
 
 pub fn set_admin(env: &Env, admin: &Address) {
-    env.storage().instance().set(&ADMIN_KEY, admin);
+    env.storage().instance().set(&DataKey::Admin, admin);
 }
 
 pub fn get_admin(env: &Env) -> Address {
     env.storage()
         .instance()
-        .get(&ADMIN_KEY)
+        .get(&DataKey::Admin)
         .expect("Admin not set")
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn balance_of(env: &Env, addr: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(addr.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_balance(env: &Env, addr: &Address, amount: &i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(addr.clone()), amount);
+}
+
+pub fn get_total_supply(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::TotalSupply)
+        .unwrap_or(0)
+}
+
+pub fn set_total_supply(env: &Env, supply: &i128) {
+    env.storage().instance().set(&DataKey::TotalSupply, supply);
 }

--- a/Contracts/contracts/token/tests/access-control.rs
+++ b/Contracts/contracts/token/tests/access-control.rs
@@ -1,16 +1,53 @@
-use soroban_sdk::{Env, testutils::Address as _};
+use soroban_sdk::{testutils::Address as _, Env, String};
 use token::TokenContract;
+
+fn setup(env: &Env) -> (soroban_sdk::Address, soroban_sdk::Address) {
+    let admin = soroban_sdk::Address::generate(env);
+    let name   = String::from_str(env, "Stellara Token");
+    let symbol = String::from_str(env, "STA");
+    TokenContract::initialize(env.clone(), admin.clone(), name, symbol, 7);
+    let other = soroban_sdk::Address::generate(env);
+    (admin, other)
+}
 
 #[test]
 #[should_panic(expected = "Unauthorized")]
 fn non_admin_cannot_mint() {
     let env = Env::default();
-
-    let admin = Address::random(&env);
-    let attacker = Address::random(&env);
-
-    TokenContract::initialize(env.clone(), admin);
-
-    // attacker tries mint
+    let (_admin, attacker) = setup(&env);
+    // attacker tries mint — require_admin will panic "Unauthorized"
     TokenContract::mint(env, attacker, 100);
+}
+
+#[test]
+fn admin_can_mint_and_balance_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, recipient) = setup(&env);
+    TokenContract::mint(env.clone(), recipient.clone(), 500);
+    assert_eq!(TokenContract::balance(env.clone(), recipient), 500);
+    assert_eq!(TokenContract::total_supply(env), 500);
+}
+
+#[test]
+fn transfer_moves_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, recipient) = setup(&env);
+    let other = soroban_sdk::Address::generate(&env);
+    TokenContract::mint(env.clone(), recipient.clone(), 1000);
+    TokenContract::transfer(env.clone(), recipient.clone(), other.clone(), 300);
+    assert_eq!(TokenContract::balance(env.clone(), recipient), 700);
+    assert_eq!(TokenContract::balance(env.clone(), other), 300);
+}
+
+#[test]
+fn burn_reduces_supply() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, holder) = setup(&env);
+    TokenContract::mint(env.clone(), holder.clone(), 1000);
+    TokenContract::burn(env.clone(), holder.clone(), 400);
+    assert_eq!(TokenContract::balance(env.clone(), holder), 600);
+    assert_eq!(TokenContract::total_supply(env), 600);
 }

--- a/Contracts/contracts/token/tests/adversarial.rs
+++ b/Contracts/contracts/token/tests/adversarial.rs
@@ -1,14 +1,58 @@
+use soroban_sdk::{testutils::Address as _, Env, String};
+use token::TokenContract;
+
+fn setup(env: &Env) -> soroban_sdk::Address {
+    let admin  = soroban_sdk::Address::generate(env);
+    let name   = String::from_str(env, "Stellara Token");
+    let symbol = String::from_str(env, "STA");
+    TokenContract::initialize(env.clone(), admin.clone(), name, symbol, 7);
+    admin
+}
+
 #[test]
 #[should_panic(expected = "Overflow")]
 fn mint_overflow_attack() {
     let env = Env::default();
-    let admin = Address::random(&env);
+    env.mock_all_auths();
+    let admin = setup(&env);
+    // First mint to i128::MAX
+    TokenContract::mint(env.clone(), admin.clone(), i128::MAX);
+    // Second mint should overflow
+    TokenContract::mint(env, admin, 1);
+}
 
-    TokenContract::initialize(env.clone(), admin.clone());
+#[test]
+#[should_panic(expected = "Insufficient balance")]
+fn transfer_beyond_balance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = setup(&env);
+    let other = soroban_sdk::Address::generate(&env);
+    TokenContract::mint(env.clone(), admin.clone(), 100);
+    TokenContract::transfer(env, admin, other, 101);
+}
 
-    TokenContract::mint(
-        env,
-        admin,
-        i128::MAX
-    );
+#[test]
+#[should_panic(expected = "Allowance exceeded")]
+fn transfer_from_beyond_allowance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin   = setup(&env);
+    let spender = soroban_sdk::Address::generate(&env);
+    let to      = soroban_sdk::Address::generate(&env);
+    TokenContract::mint(env.clone(), admin.clone(), 1000);
+    TokenContract::approve(env.clone(), admin.clone(), spender.clone(), 50, 0);
+    TokenContract::transfer_from(env, spender, admin, to, 51);
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn double_initialize_blocked() {
+    let env  = Env::default();
+    env.mock_all_auths();
+    let admin  = soroban_sdk::Address::generate(&env);
+    let name   = String::from_str(&env, "Stellara Token");
+    let symbol = String::from_str(&env, "STA");
+    TokenContract::initialize(env.clone(), admin.clone(), name.clone(), symbol.clone(), 7);
+    TokenContract::initialize(env, admin, name, symbol, 7);
 }


### PR DESCRIPTION
# fix(contracts): resolve token interface inconsistencies

**Closes #771**

---

## What this PR fixes

Issue #771 identified three categories of interface inconsistency across the Stellara Soroban workspace. All three are resolved here, scoped entirely to `Contracts/` — no Backend or Frontend changes.

---

## Change 1 — Token contract: compile error + full SEP-41 interface

The token contract had **two compile errors** (functions called but never defined) and was missing the bulk of the SEP-41 interface that every other contract in the workspace calls via `soroban_sdk::token::Client`.

### `contracts/token/src/storage.rs`
- Added missing `has_admin`, `balance_of`, `set_balance` (were called in `libs.rs` but never defined — hard compile failure)
- Added `get_total_supply` / `set_total_supply`
- Replaced bare `Symbol::short` storage keys with a typed `DataKey` enum (consistent with every other contract in the workspace; prevents key collisions)

### `contracts/token/src/libs.rs`
Extended from 2 exported functions to the full SEP-41 surface:

| Function | Before | After |
|---|---|---|
| `initialize` | ✅ (no metadata params) | ✅ (+ `name`, `symbol`, `decimals`) |
| `mint` | ✅ | ✅ |
| `name` / `symbol` / `decimals` | ❌ | ✅ |
| `total_supply` | ❌ | ✅ |
| `balance` | ❌ | ✅ |
| `transfer` / `transfer_from` | ❌ | ✅ |
| `approve` / `allowance` | ❌ | ✅ |
| `burn` / `burn_from` | ❌ | ✅ |
| `set_admin` | ❌ | ✅ |
| On-chain events | ❌ | ✅ (`transfer`, `mint`, `burn`, `approve`) |

### `contracts/token/tests/`
Both test files updated to match the new `initialize` signature and to add coverage for `transfer`, `burn`, double-init guard, and allowance boundary checks.

---

## Change 2 — Standardise `init` → `initialize` across all contracts

7 contracts used `init` as their entry-point name while 11 used `initialize`. The split was already visible in `integration-tests/tests/cross_contract.rs` which mixed both in the same file.

**Renamed `pub fn init(` → `pub fn initialize(` in:**
- `contracts/trading/src/lib.rs`
- `contracts/messaging/src/lib.rs`
- `contracts/social_rewards/src/lib.rs`
- `contracts/academy/src/vesting.rs`
- `contracts/amm/src/lib.rs`
- `contracts/parametric_insurance/src/lib.rs`
- `contracts/cross-chain-router/src/lib.rs`

**Updated all call sites in:**
- `contracts/trading/src/test.rs`
- `contracts/messaging/src/test.rs`
- `contracts/amm/src/test.rs`
- `contracts/academy/src/test.rs`
- `contracts/parametric_insurance/tests/integration.rs`
- `integration-tests/tests/cross_contract.rs`

> **Note:** `shared::circuit_breaker::CircuitBreaker::init` is an internal Rust helper function (not a contract entry-point exported via `#[contractimpl]`) and is intentionally left unchanged.

---

## Change 3 — Centralise vesting event topics in `shared::events`

Academy/vesting was emitting events via raw `symbol_short!("grant")`, `symbol_short!("claim")` etc. while `shared/src/events.rs` already had a `topics` module for canonical event names. Off-chain indexers subscribing to those topics were getting nothing from vesting.

### `shared/src/events.rs`
Added to the `topics` module:
```rust
pub const APPROVE:         Symbol = symbol_short!("approve");
pub const VESTING_GRANTED: Symbol = symbol_short!("v_grant");
pub const VESTING_CLAIMED: Symbol = symbol_short!("v_claim");
pub const VESTING_REVOKED: Symbol = symbol_short!("v_revoke");
```

### `contracts/academy/src/vesting.rs`
- Added `use shared::events::topics;`
- Replaced all 4 raw `symbol_short!()` event publish calls with the canonical constants

---

## Files changed (18)

```
Contracts/contracts/token/src/storage.rs
Contracts/contracts/token/src/libs.rs
Contracts/contracts/token/tests/access-control.rs
Contracts/contracts/token/tests/adversarial.rs
Contracts/contracts/trading/src/lib.rs
Contracts/contracts/trading/src/test.rs
Contracts/contracts/messaging/src/lib.rs
Contracts/contracts/messaging/src/test.rs
Contracts/contracts/social_rewards/src/lib.rs
Contracts/contracts/academy/src/vesting.rs
Contracts/contracts/academy/src/test.rs
Contracts/contracts/amm/src/lib.rs
Contracts/contracts/amm/src/test.rs
Contracts/contracts/parametric_insurance/src/lib.rs
Contracts/contracts/parametric_insurance/tests/integration.rs
Contracts/contracts/cross-chain-router/src/lib.rs
Contracts/shared/src/events.rs
Contracts/integration-tests/tests/cross_contract.rs
```

---

## Testing

- All existing snapshot tests in `contracts/trading/`, `contracts/messaging/`, `contracts/academy/`, `contracts/amm/` remain valid (only the function name changed, not its arguments or behaviour)
- New token tests in `access-control.rs` and `adversarial.rs` cover the expanded interface
- Integration test call sites in `cross_contract.rs` updated to `initialize` throughout — no functional change to test logic

---

## Checklist

- [x] Consistent `initialize` ABI across all 18 contract modules
- [x] Token contract storage helpers defined (compile error resolved)  
- [x] Token ABI matches `soroban_sdk::token::Client` expectations
- [x] On-chain events emitted by token contract
- [x] Vesting event topics centralised in `shared::events`
- [x] All integration test call sites updated
- [x] No Backend or Frontend files touched
