### PR TITLE
ContractModule: Governance Proposal Edge Cases & Test Coverage

### DIFF
--- a/Contracts/GOVERNANCE_TESTING.md
+++ b/Contracts/GOVERNANCE_TESTING.md
@@ -1,0 +1,101 @@
+# Governance Testing & Known Limitations
+
+This document describes the test coverage for the shared governance module
+(`shared/src/governance.rs`) that powers upgradeability across the Stellara
+contracts, with a focus on the **complex proposal flows** — timelocks, edge
+votes, and quorum edge cases — and documents **known limitations** with their
+mitigations.
+
+## Why this exists
+
+The governance module is the trust layer for all contract upgrades (multi-sig
+approvals + timelock). The happy-path tests inside each contract
+(`contracts/trading/src/test.rs`) covered the nominal lifecycle, but the fringe
+cases (impossible quorums, zero/boundary timelocks, out-of-order state
+transitions, role edge cases) were untested — leaving room for unexpected
+behaviour on edge cases. The suites below close that gap.
+
+## Test inventory
+
+### 1. Module-level unit & bounded-fuzz tests — `shared/tests/governance.rs`
+
+Drives `GovernanceManager` directly (under `env.as_contract`) so the reusable
+building block is verified in isolation.
+
+| Area | Tests |
+| --- | --- |
+| Quorum / threshold | `fuzz_quorum_flips_exactly_at_threshold` (sweeps every `(n, threshold)` for `n ≤ 6`), `single_approver_single_threshold_approves_immediately`, `unanimous_threshold_requires_every_approver`, `threshold_zero_is_rejected`, `threshold_greater_than_approvers_is_rejected`, `empty_approver_set_cannot_form_a_quorum` |
+| Edge votes | `approver_not_in_proposal_list_is_unauthorized`, `duplicate_approval_is_rejected`, `approval_after_quorum_reached_is_rejected` |
+| Timelock | `fuzz_timelock_boundary_enforced` (sweeps `{0, 1, 100, 3600, 86400, 14400}`, checks one-second-early failure + exact-expiry success), `zero_timelock_allows_immediate_execution`, `overflowing_timelock_delay_panics` |
+| State machine | `cannot_execute_before_approval`, `cannot_execute_twice`, `reject_blocks_subsequent_approval_and_execution`, `cancel_blocks_execution`, `cannot_cancel_after_execution`, `cancel_overwrites_a_rejected_proposal`, `get_unknown_proposal_returns_not_found`, `proposal_ids_increment_independently` |
+| Role-based access | `non_admin_cannot_propose`, `unknown_address_cannot_approve`, `execution_is_permissionless_for_any_address` |
+
+### 2. End-to-end scenario & fuzz tests — `integration-tests/tests/governance_flows.rs`
+
+Drives the full contract path through real contract clients (`require_auth`,
+role wiring via `init`, error mapping, ledger timelock progression).
+
+| Area | Tests |
+| --- | --- |
+| Full lifecycle | `full_2of3_lifecycle_executes_after_timelock` |
+| Quorum edge cases | `quorum_not_met_blocks_execution`, `invalid_threshold_zero_is_rejected_at_proposal_time`, `threshold_above_approver_count_is_rejected`, `approver_excluded_from_proposal_subset_cannot_approve`, `duplicate_and_post_quorum_approvals_are_rejected` |
+| Timelock | `timelock_one_second_early_fails_exact_expiry_succeeds` |
+| Reject / cancel | `rejected_proposal_cannot_be_executed`, `cancelled_proposal_cannot_be_executed`, `cannot_execute_twice` |
+| Concurrency / upgrades | `concurrent_proposals_have_independent_state`, `simulate_upgrade_across_two_contracts`, `fuzz_quorum_and_execution_through_contract` (sweeps `(n, threshold)` for `n ≤ 4`) |
+
+## How to run
+
+```bash
+cd Contracts
+
+# Module-level governance unit + fuzz tests
+cargo test -p shared --test governance
+
+# End-to-end governance scenario + fuzz tests
+cargo test -p integration-tests --test governance_flows
+
+# Everything
+cargo test --all
+```
+
+## Known limitations & mitigations
+
+These behaviours are **intentionally captured by tests** so any future change is
+caught by CI. They are documented rather than silently changed because altering
+them affects on-chain semantics and is out of scope for a test-hardening change.
+
+1. **Execution is permissionless.**
+   An address with no assigned role defaults to the lowest-privilege `Executor`
+   role, so `execute_proposal` accepts any caller for an already-approved,
+   timelock-expired proposal (`execution_is_permissionless_for_any_address`).
+   *Impact:* low — execution only finalizes a proposal that already cleared
+   multi-sig approval and the timelock; it cannot bypass either gate.
+   *Mitigation:* if a dedicated executor is required, assign an explicit
+   `Executor`-or-higher role and tighten `require_role` to reject the implicit
+   default, or gate `execute_upgrade` with `require_auth` on a known executor.
+
+2. **Zero timelock allows same-ledger execution.**
+   `propose_upgrade` accepts `timelock_delay == 0`, permitting execution in the
+   same ledger as approval (`zero_timelock_allows_immediate_execution`).
+   *Mitigation:* callers should pass a non-zero `timelock_delay`; consider
+   enforcing a protocol-level minimum (e.g. 1 hour) at the contract entry point.
+
+3. **`timelock_delay` is unchecked arithmetic.**
+   `created_at + timelock_delay` can overflow `u64` for absurd values
+   (`overflowing_timelock_delay_panics`).
+   *Mitigation:* bound `timelock_delay` (e.g. ≤ 30 days) before calling
+   `propose_upgrade`; a `checked_add` would harden this further.
+
+4. **Loose terminal-state handling for `cancel`.**
+   `cancel_proposal` only guards the `executed` flag, so a `Rejected` proposal
+   can still be transitioned to `Cancelled` (`cancel_overwrites_a_rejected_proposal`).
+   *Impact:* cosmetic — both are non-actionable terminal states; a cancelled or
+   rejected proposal can never be approved or executed.
+   *Mitigation:* if strict state hygiene is desired, reject `cancel` on any
+   already-terminal (`Rejected`/`Cancelled`/`Executed`) proposal.
+
+5. **WASM swap is environment-level.**
+   In the local test environment, `execute_upgrade` records governance
+   bookkeeping (status → `Executed`); the actual on-chain WASM replacement is a
+   ledger operation outside the scope of these unit-style tests
+   (`simulate_upgrade_across_two_contracts` validates the bookkeeping path).

--- a/Contracts/integration-tests/tests/governance_flows.rs
+++ b/Contracts/integration-tests/tests/governance_flows.rs
@@ -1,0 +1,528 @@
+//! End-to-end, scenario-based governance tests for complex proposal flows.
+//!
+//! Unlike the unit tests in `shared/tests/governance.rs` (which drive
+//! `GovernanceManager` directly), these tests exercise the *full contract path*
+//! through real upgradeable contract clients — `require_auth`, role wiring done
+//! in `init`, error mapping, and timelock progression on the ledger.
+//!
+//! Coverage focus (the fringe cases called out in the governance hardening issue):
+//! * full multi-sig upgrade lifecycle (propose -> approve -> timelock -> execute),
+//! * quorum edge cases (threshold not met, exact threshold, single/unanimous),
+//! * timelock boundaries (one second early vs. exact expiry),
+//! * reject / cancel paths blocking execution,
+//! * unauthorized approvers and duplicate / post-quorum approvals,
+//! * simulated upgrades across two independent contracts sharing the module,
+//! * a bounded fuzz sweep over (approver count, threshold) combinations.
+
+#![cfg(test)]
+
+extern crate std;
+
+use messaging::UpgradeableMessagingContract;
+use shared::circuit_breaker::CircuitBreakerConfig;
+use shared::governance::ProposalStatus;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env, Vec,
+};
+use trading::{UpgradeableTradingContract, UpgradeableTradingContractClient};
+
+const BASE_TS: u64 = 1_000;
+
+fn cb_config() -> CircuitBreakerConfig {
+    CircuitBreakerConfig {
+        max_volume_per_period: 1_000_000_000,
+        max_tx_count_per_period: 100,
+        period_duration: 3600,
+    }
+}
+
+/// Spin up a trading contract initialized with `n` approvers and an executor.
+/// Returns the client plus the governance actors.
+fn setup_trading(
+    env: &Env,
+    n: u32,
+) -> (
+    UpgradeableTradingContractClient<'_>,
+    Address,
+    Vec<Address>,
+    Address,
+) {
+    let contract_id = env.register_contract(None, UpgradeableTradingContract);
+    let client = UpgradeableTradingContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let executor = Address::generate(env);
+    let mut approvers = Vec::new(env);
+    for _ in 0..n {
+        approvers.push_back(Address::generate(env));
+    }
+
+    client.init(&admin, &approvers, &executor, &cb_config());
+    (client, admin, approvers, executor)
+}
+
+// ----------------------------------------------------------------------------
+// Full lifecycle
+// ----------------------------------------------------------------------------
+
+#[test]
+fn full_2of3_lifecycle_executes_after_timelock() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 3);
+    let timelock = 14_400u64;
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &2u32,
+        &timelock,
+    );
+
+    // First approval -> still pending.
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Pending
+    );
+
+    // Second approval -> quorum reached.
+    client.approve_upgrade(&pid, &approvers.get(1).unwrap());
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Approved
+    );
+
+    // Timelock not yet elapsed -> execution blocked.
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+
+    // Advance past the timelock and execute.
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS + timelock);
+    client.execute_upgrade(&pid, &executor);
+
+    let prop = client.get_upgrade_proposal(&pid);
+    assert_eq!(prop.status, ProposalStatus::Executed);
+    assert!(prop.executed);
+}
+
+// ----------------------------------------------------------------------------
+// Quorum edge cases
+// ----------------------------------------------------------------------------
+
+#[test]
+fn quorum_not_met_blocks_execution() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 3);
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &3u32, // unanimous required
+        &0u64,
+    );
+
+    // Only two of three approve.
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+    client.approve_upgrade(&pid, &approvers.get(1).unwrap());
+
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Pending
+    );
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+}
+
+#[test]
+fn invalid_threshold_zero_is_rejected_at_proposal_time() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, _executor) = setup_trading(&env, 2);
+
+    let res = client.try_propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &0u32,
+        &0u64,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn threshold_above_approver_count_is_rejected() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, _executor) = setup_trading(&env, 2);
+
+    let res = client.try_propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &3u32, // > 2 approvers
+        &0u64,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn approver_excluded_from_proposal_subset_cannot_approve() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    // The contract is initialized with two approvers (both hold the Approver
+    // role), but the proposal restricts the approver set to just the first one.
+    let (client, admin, approvers, _executor) = setup_trading(&env, 2);
+    let included = approvers.get(0).unwrap();
+    let excluded = approvers.get(1).unwrap();
+
+    let mut subset = Vec::new(&env);
+    subset.push_back(included.clone());
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &subset,
+        &1u32,
+        &0u64,
+    );
+
+    // `excluded` has the Approver role but is not on this proposal's list, so the
+    // call is cleanly rejected (recoverable error) without changing the count.
+    assert!(client.try_approve_upgrade(&pid, &excluded).is_err());
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).approvals_count,
+        0,
+        "rejected approval must not change the count"
+    );
+}
+
+#[test]
+fn duplicate_and_post_quorum_approvals_are_rejected() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, _executor) = setup_trading(&env, 2);
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1u32,
+        &0u64,
+    );
+
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+    // Quorum already reached -> the first approver's repeat and the second
+    // approver's late vote are both rejected.
+    assert!(client.try_approve_upgrade(&pid, &approvers.get(0).unwrap()).is_err());
+    assert!(client.try_approve_upgrade(&pid, &approvers.get(1).unwrap()).is_err());
+    assert_eq!(client.get_upgrade_proposal(&pid).approvals_count, 1);
+}
+
+// ----------------------------------------------------------------------------
+// Timelock boundary
+// ----------------------------------------------------------------------------
+
+#[test]
+fn timelock_one_second_early_fails_exact_expiry_succeeds() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 1);
+    let timelock = 3_600u64;
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1u32,
+        &timelock,
+    );
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+
+    // One second before expiry -> blocked.
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS + timelock - 1);
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+
+    // Exactly at expiry -> allowed.
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS + timelock);
+    client.execute_upgrade(&pid, &executor);
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Executed
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Reject / cancel paths
+// ----------------------------------------------------------------------------
+
+#[test]
+fn rejected_proposal_cannot_be_executed() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 2);
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1u32,
+        &0u64,
+    );
+
+    client.reject_upgrade(&pid, &approvers.get(0).unwrap());
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Rejected
+    );
+    // A rejected proposal can no longer be approved or executed.
+    assert!(client.try_approve_upgrade(&pid, &approvers.get(1).unwrap()).is_err());
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+}
+
+#[test]
+fn cancelled_proposal_cannot_be_executed() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 1);
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1u32,
+        &0u64,
+    );
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+
+    // Admin cancels even though quorum was reached.
+    client.cancel_upgrade(&pid, &admin);
+    assert_eq!(
+        client.get_upgrade_proposal(&pid).status,
+        ProposalStatus::Cancelled
+    );
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+}
+
+#[test]
+fn cannot_execute_twice() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, executor) = setup_trading(&env, 1);
+
+    let pid = client.propose_upgrade(
+        &admin,
+        &symbol_short!("v2hash"),
+        &symbol_short!("Upgrade"),
+        &approvers,
+        &1u32,
+        &0u64,
+    );
+    client.approve_upgrade(&pid, &approvers.get(0).unwrap());
+    client.execute_upgrade(&pid, &executor);
+    assert!(client.try_execute_upgrade(&pid, &executor).is_err());
+}
+
+// ----------------------------------------------------------------------------
+// Concurrency / multi-proposal & cross-contract simulation
+// ----------------------------------------------------------------------------
+
+#[test]
+fn concurrent_proposals_have_independent_state() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    let (client, admin, approvers, _executor) = setup_trading(&env, 2);
+
+    let p1 = client.propose_upgrade(
+        &admin,
+        &symbol_short!("h1"),
+        &symbol_short!("d1"),
+        &approvers,
+        &1u32,
+        &0u64,
+    );
+    let p2 = client.propose_upgrade(
+        &admin,
+        &symbol_short!("h2"),
+        &symbol_short!("d2"),
+        &approvers,
+        &2u32,
+        &0u64,
+    );
+
+    assert_eq!(p1, 1);
+    assert_eq!(p2, 2);
+
+    // Approving p1 to quorum must not affect p2.
+    client.approve_upgrade(&p1, &approvers.get(0).unwrap());
+    assert_eq!(
+        client.get_upgrade_proposal(&p1).status,
+        ProposalStatus::Approved
+    );
+    assert_eq!(
+        client.get_upgrade_proposal(&p2).status,
+        ProposalStatus::Pending
+    );
+}
+
+/// Simulate a coordinated governance upgrade across two independent contracts
+/// that share the governance module. Validates that proposal bookkeeping and the
+/// timelock are tracked independently per contract.
+///
+/// Note: in the local test environment `execute_upgrade` records the proposal as
+/// executed (governance bookkeeping); the on-chain WASM swap itself is a
+/// ledger-level operation outside the scope of these unit-style tests.
+#[test]
+fn simulate_upgrade_across_two_contracts() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.mock_all_auths();
+
+    // Trading contract.
+    let (trading, t_admin, t_approvers, t_executor) = setup_trading(&env, 2);
+
+    // Messaging contract sharing the same governance actors set.
+    let messaging_id = env.register_contract(None, UpgradeableMessagingContract);
+    let messaging = messaging::UpgradeableMessagingContractClient::new(&env, &messaging_id);
+    let m_admin = Address::generate(&env);
+    let m_executor = Address::generate(&env);
+    let mut m_approvers = Vec::new(&env);
+    m_approvers.push_back(Address::generate(&env));
+    m_approvers.push_back(Address::generate(&env));
+    messaging.init(&m_admin, &m_approvers, &m_executor, &cb_config());
+
+    let timelock = 7_200u64;
+
+    let t_pid = trading.propose_upgrade(
+        &t_admin,
+        &symbol_short!("tv2"),
+        &symbol_short!("UpgrTrade"),
+        &t_approvers,
+        &2u32,
+        &timelock,
+    );
+    let m_pid = messaging.propose_upgrade(
+        &m_admin,
+        &symbol_short!("mv2"),
+        &symbol_short!("UpgrMsg"),
+        &m_approvers,
+        &2u32,
+        &timelock,
+    );
+
+    trading.approve_upgrade(&t_pid, &t_approvers.get(0).unwrap());
+    trading.approve_upgrade(&t_pid, &t_approvers.get(1).unwrap());
+    messaging.approve_upgrade(&m_pid, &m_approvers.get(0).unwrap());
+    messaging.approve_upgrade(&m_pid, &m_approvers.get(1).unwrap());
+
+    assert_eq!(
+        trading.get_upgrade_proposal(&t_pid).status,
+        ProposalStatus::Approved
+    );
+    assert_eq!(
+        messaging.get_upgrade_proposal(&m_pid).status,
+        ProposalStatus::Approved
+    );
+
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS + timelock);
+    trading.execute_upgrade(&t_pid, &t_executor);
+    messaging.execute_upgrade(&m_pid, &m_executor);
+
+    assert_eq!(
+        trading.get_upgrade_proposal(&t_pid).status,
+        ProposalStatus::Executed
+    );
+    assert_eq!(
+        messaging.get_upgrade_proposal(&m_pid).status,
+        ProposalStatus::Executed
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Bounded fuzz sweep through the real contract path
+// ----------------------------------------------------------------------------
+
+/// Bounded fuzz: for each (approver count, threshold) combination, a fresh
+/// contract is initialized and the proposal is approved one vote at a time. The
+/// proposal must reach `Approved` exactly when the threshold is hit and become
+/// executable only after the timelock elapses.
+#[test]
+fn fuzz_quorum_and_execution_through_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    for n in 1u32..=4 {
+        for threshold in 1u32..=n {
+            env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+            let (client, admin, approvers, executor) = setup_trading(&env, n);
+            let timelock = 100u64;
+
+            let pid = client.propose_upgrade(
+                &admin,
+                &symbol_short!("vh"),
+                &symbol_short!("desc"),
+                &approvers,
+                &threshold,
+                &timelock,
+            );
+
+            for i in 0..threshold {
+                client.approve_upgrade(&pid, &approvers.get(i).unwrap());
+            }
+
+            assert_eq!(
+                client.get_upgrade_proposal(&pid).status,
+                ProposalStatus::Approved,
+                "n={n} threshold={threshold} should be Approved at quorum"
+            );
+
+            // Still timelocked.
+            assert!(
+                client.try_execute_upgrade(&pid, &executor).is_err(),
+                "n={n} threshold={threshold} should be timelocked"
+            );
+
+            env.ledger().with_mut(|li| li.timestamp = BASE_TS + timelock);
+            client.execute_upgrade(&pid, &executor);
+            assert_eq!(
+                client.get_upgrade_proposal(&pid).status,
+                ProposalStatus::Executed,
+                "n={n} threshold={threshold} should execute after timelock"
+            );
+        }
+    }
+}

--- a/Contracts/shared/tests/governance.rs
+++ b/Contracts/shared/tests/governance.rs
@@ -1,0 +1,818 @@
+//! Edge-case, scenario, and bounded-fuzz tests for the shared governance module.
+//!
+//! These tests exercise [`shared::governance::GovernanceManager`] *directly* (i.e.
+//! the reusable building block every upgradeable contract depends on) rather than
+//! going through a single contract client. They focus on the fringe behaviours the
+//! happy-path contract tests do not cover:
+//!
+//! * quorum / threshold boundaries (single, unanimous, impossible),
+//! * timelock boundaries (zero delay, one-second-before, exact expiry),
+//! * proposal state-machine transitions (reject/cancel/execute ordering),
+//! * role-based access control panics,
+//! * documented fringe behaviours that are intentionally captured here so any
+//!   change in behaviour is caught by CI (see `GOVERNANCE_TESTING.md`).
+//!
+//! Where a behaviour is a *known limitation* the test name and comment say so.
+
+extern crate std;
+
+use shared::governance::{GovernanceError, GovernanceManager, GovernanceRole, ProposalStatus};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env, Map, Symbol, Vec,
+};
+
+/// Minimal host contract used only to provide a contract-storage context so the
+/// governance helpers (which read/write persistent storage) can run under
+/// `env.as_contract`.
+#[contract]
+pub struct GovHost;
+
+#[contractimpl]
+impl GovHost {}
+
+const ROLES_KEY: Symbol = symbol_short!("roles");
+const BASE_TS: u64 = 1_000_000;
+
+/// Register the host contract and pin a deterministic ledger timestamp.
+fn setup(env: &Env) -> Address {
+    env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+    env.register_contract(None, GovHost)
+}
+
+/// Write the role map exactly the way the production contracts do during `init`.
+/// Must be called inside an `env.as_contract` closure.
+fn set_roles(env: &Env, admin: &Address, approvers: &Vec<Address>, executor: &Address) {
+    let mut roles: Map<Address, GovernanceRole> = Map::new(env);
+    roles.set(admin.clone(), GovernanceRole::Admin);
+    for approver in approvers.iter() {
+        roles.set(approver, GovernanceRole::Approver);
+    }
+    roles.set(executor.clone(), GovernanceRole::Executor);
+    env.storage().persistent().set(&ROLES_KEY, &roles);
+}
+
+/// Build a `Vec<Address>` of freshly generated approver addresses.
+fn make_approvers(env: &Env, n: u32) -> Vec<Address> {
+    let mut approvers = Vec::new(env);
+    for _ in 0..n {
+        approvers.push_back(Address::generate(env));
+    }
+    approvers
+}
+
+// ----------------------------------------------------------------------------
+// Quorum / threshold edge cases
+// ----------------------------------------------------------------------------
+
+/// Bounded fuzz: for every (n approvers, threshold in 1..=n) combination the
+/// proposal must flip to `Approved` *exactly* when the running approval count
+/// reaches the threshold — never before.
+#[test]
+fn fuzz_quorum_flips_exactly_at_threshold() {
+    let env = Env::default();
+    let id = setup(&env);
+
+    for n in 1u32..=6 {
+        for threshold in 1u32..=n {
+            let admin = Address::generate(&env);
+            let executor = Address::generate(&env);
+            let approvers = make_approvers(&env, n);
+
+            env.as_contract(&id, || {
+                set_roles(&env, &admin, &approvers, &executor);
+
+                let pid = GovernanceManager::propose_upgrade(
+                    &env,
+                    admin.clone(),
+                    symbol_short!("hash"),
+                    id.clone(),
+                    symbol_short!("desc"),
+                    threshold,
+                    approvers.clone(),
+                    100,
+                )
+                .unwrap();
+
+                for i in 0..n {
+                    let approver = approvers.get(i).unwrap();
+                    GovernanceManager::approve_proposal(&env, pid, approver).unwrap();
+
+                    let approved_so_far = i + 1;
+                    let prop = GovernanceManager::get_proposal(&env, pid).unwrap();
+
+                    if approved_so_far >= threshold {
+                        assert_eq!(
+                            prop.status,
+                            ProposalStatus::Approved,
+                            "n={n} threshold={threshold} count={approved_so_far} should be Approved"
+                        );
+                        // Once approved the proposal is no longer Pending, so any
+                        // further approval is rejected; stop here.
+                        break;
+                    } else {
+                        assert_eq!(
+                            prop.status,
+                            ProposalStatus::Pending,
+                            "n={n} threshold={threshold} count={approved_so_far} should still be Pending"
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
+#[test]
+fn single_approver_single_threshold_approves_immediately() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Approved
+        );
+    });
+}
+
+#[test]
+fn unanimous_threshold_requires_every_approver() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 3);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            3, // unanimous
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(1).unwrap()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Pending
+        );
+
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(2).unwrap()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Approved
+        );
+    });
+}
+
+#[test]
+fn threshold_zero_is_rejected() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let res = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            0,
+            approvers.clone(),
+            100,
+        );
+        assert_eq!(res, Err(GovernanceError::InvalidThreshold));
+    });
+}
+
+#[test]
+fn threshold_greater_than_approvers_is_rejected() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let res = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            3, // > 2 approvers
+            approvers.clone(),
+            100,
+        );
+        assert_eq!(res, Err(GovernanceError::InvalidThreshold));
+    });
+}
+
+#[test]
+fn empty_approver_set_cannot_form_a_quorum() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 0);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        // threshold 1 against 0 approvers is impossible -> InvalidThreshold.
+        let res = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        );
+        assert_eq!(res, Err(GovernanceError::InvalidThreshold));
+    });
+}
+
+#[test]
+fn approver_not_in_proposal_list_is_unauthorized() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+    // An address that holds the Approver role globally but is NOT on this
+    // proposal's approver list.
+    let outsider = Address::generate(&env);
+
+    env.as_contract(&id, || {
+        let mut roles: Map<Address, GovernanceRole> = Map::new(&env);
+        roles.set(admin.clone(), GovernanceRole::Admin);
+        for a in approvers.iter() {
+            roles.set(a, GovernanceRole::Approver);
+        }
+        roles.set(outsider.clone(), GovernanceRole::Approver);
+        roles.set(executor.clone(), GovernanceRole::Executor);
+        env.storage().persistent().set(&ROLES_KEY, &roles);
+
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+
+        let res = GovernanceManager::approve_proposal(&env, pid, outsider.clone());
+        assert_eq!(res, Err(GovernanceError::Unauthorized));
+    });
+}
+
+#[test]
+fn duplicate_approval_is_rejected() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 3);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            2,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        let res = GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap());
+        assert_eq!(res, Err(GovernanceError::DuplicateApproval));
+        // The rejected duplicate must not have inflated the count.
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().approvals_count,
+            1
+        );
+    });
+}
+
+#[test]
+fn approval_after_quorum_reached_is_rejected() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        // Already Approved -> further approvals are invalid.
+        let res = GovernanceManager::approve_proposal(&env, pid, approvers.get(1).unwrap());
+        assert_eq!(res, Err(GovernanceError::InvalidProposal));
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Timelock edge cases
+// ----------------------------------------------------------------------------
+
+/// Bounded fuzz over a spread of timelock delays. For every delay the proposal
+/// must be executable at `created_at + delay` and (for non-zero delays) NOT one
+/// second earlier.
+#[test]
+fn fuzz_timelock_boundary_enforced() {
+    let env = Env::default();
+    let id = setup(&env);
+
+    for delay in [0u64, 1, 100, 3_600, 86_400, 14_400] {
+        let admin = Address::generate(&env);
+        let executor = Address::generate(&env);
+        let approvers = make_approvers(&env, 1);
+
+        env.ledger().with_mut(|li| li.timestamp = BASE_TS);
+
+        env.as_contract(&id, || {
+            set_roles(&env, &admin, &approvers, &executor);
+            let pid = GovernanceManager::propose_upgrade(
+                &env,
+                admin.clone(),
+                symbol_short!("hash"),
+                id.clone(),
+                symbol_short!("desc"),
+                1,
+                approvers.clone(),
+                delay,
+            )
+            .unwrap();
+            GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+
+            let prop = GovernanceManager::get_proposal(&env, pid).unwrap();
+            assert_eq!(prop.execution_time, BASE_TS + delay);
+
+            if delay > 0 {
+                // One second before expiry must fail.
+                env.ledger().with_mut(|li| li.timestamp = BASE_TS + delay - 1);
+                let early = GovernanceManager::execute_proposal(&env, pid, executor.clone());
+                assert_eq!(early, Err(GovernanceError::TimelockNotExpired));
+            }
+
+            // Exactly at expiry must succeed.
+            env.ledger().with_mut(|li| li.timestamp = BASE_TS + delay);
+            GovernanceManager::execute_proposal(&env, pid, executor.clone()).unwrap();
+            assert_eq!(
+                GovernanceManager::get_proposal(&env, pid).unwrap().status,
+                ProposalStatus::Executed
+            );
+        });
+    }
+}
+
+/// KNOWN BEHAVIOUR: a zero timelock means an approved proposal can be executed in
+/// the same ledger it was approved. Captured so the safety implication is visible
+/// (see `GOVERNANCE_TESTING.md` — callers should enforce a minimum delay).
+#[test]
+fn zero_timelock_allows_immediate_execution() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        // No time advance at all.
+        GovernanceManager::execute_proposal(&env, pid, executor.clone()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Executed
+        );
+    });
+}
+
+/// KNOWN LIMITATION: `created_at + timelock_delay` is unchecked arithmetic, so an
+/// absurd delay overflows `u64` and panics (in debug) / wraps (in release).
+/// Callers must bound `timelock_delay`. This test pins the debug-mode panic.
+#[test]
+#[should_panic]
+fn overflowing_timelock_delay_panics() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let _ = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            u64::MAX,
+        );
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Proposal state-machine transitions
+// ----------------------------------------------------------------------------
+
+#[test]
+fn cannot_execute_before_approval() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            2,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        // Only one of two approvals -> still Pending.
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        let res = GovernanceManager::execute_proposal(&env, pid, executor.clone());
+        assert_eq!(res, Err(GovernanceError::ProposalNotApproved));
+    });
+}
+
+#[test]
+fn cannot_execute_twice() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        GovernanceManager::execute_proposal(&env, pid, executor.clone()).unwrap();
+        let res = GovernanceManager::execute_proposal(&env, pid, executor.clone());
+        assert_eq!(res, Err(GovernanceError::ProposalNotApproved));
+    });
+}
+
+#[test]
+fn reject_blocks_subsequent_approval_and_execution() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 2);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+
+        GovernanceManager::reject_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Rejected
+        );
+
+        // A rejected proposal can no longer be approved...
+        let approve = GovernanceManager::approve_proposal(&env, pid, approvers.get(1).unwrap());
+        assert_eq!(approve, Err(GovernanceError::InvalidProposal));
+        // ...and double rejection is also invalid.
+        let reject_again = GovernanceManager::reject_proposal(&env, pid, approvers.get(1).unwrap());
+        assert_eq!(reject_again, Err(GovernanceError::InvalidProposal));
+    });
+}
+
+#[test]
+fn cancel_blocks_execution() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::cancel_proposal(&env, pid, admin.clone()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Cancelled
+        );
+        // A cancelled proposal is not Approved, so execution fails.
+        let res = GovernanceManager::execute_proposal(&env, pid, executor.clone());
+        assert_eq!(res, Err(GovernanceError::ProposalNotApproved));
+    });
+}
+
+#[test]
+fn cannot_cancel_after_execution() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        GovernanceManager::execute_proposal(&env, pid, executor.clone()).unwrap();
+
+        let res = GovernanceManager::cancel_proposal(&env, pid, admin.clone());
+        assert_eq!(res, Err(GovernanceError::InvalidProposal));
+    });
+}
+
+/// KNOWN BEHAVIOUR: `cancel_proposal` only guards against the `executed` flag, so
+/// an already-rejected proposal can still be transitioned to `Cancelled`. Pinned
+/// here so the loose terminal-state handling is visible (see docs).
+#[test]
+fn cancel_overwrites_a_rejected_proposal() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::reject_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        // Currently allowed: Rejected -> Cancelled.
+        GovernanceManager::cancel_proposal(&env, pid, admin.clone()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Cancelled
+        );
+    });
+}
+
+#[test]
+fn get_unknown_proposal_returns_not_found() {
+    let env = Env::default();
+    let id = setup(&env);
+
+    env.as_contract(&id, || {
+        // No proposals map exists yet.
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, 1),
+            Err(GovernanceError::ProposalNotFound)
+        );
+    });
+}
+
+#[test]
+fn proposal_ids_increment_independently() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let first = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("h1"),
+            id.clone(),
+            symbol_short!("d1"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+        let second = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("h2"),
+            id.clone(),
+            symbol_short!("d2"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+    });
+}
+
+// ----------------------------------------------------------------------------
+// Role-based access control (panics)
+// ----------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "UNAUTH")]
+fn non_admin_cannot_propose() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+    let approver = approvers.get(0).unwrap();
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        // An Approver (role 1) is not allowed to propose (needs Admin role 0).
+        let _ = GovernanceManager::propose_upgrade(
+            &env,
+            approver.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        );
+    });
+}
+
+#[test]
+#[should_panic(expected = "UNAUTH")]
+fn unknown_address_cannot_approve() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+    let stranger = Address::generate(&env);
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            100,
+        )
+        .unwrap();
+        // Stranger has no role -> defaults to Executor (lowest) -> fails the
+        // Approver requirement and panics.
+        let _ = GovernanceManager::approve_proposal(&env, pid, stranger.clone());
+    });
+}
+
+/// KNOWN LIMITATION: because an address with no assigned role defaults to the
+/// lowest-privilege `Executor` role, the `execute` step is effectively
+/// permissionless — any address can execute an already-approved, timelock-expired
+/// proposal. Captured here and documented in `GOVERNANCE_TESTING.md`.
+#[test]
+fn execution_is_permissionless_for_any_address() {
+    let env = Env::default();
+    let id = setup(&env);
+    let admin = Address::generate(&env);
+    let executor = Address::generate(&env);
+    let approvers = make_approvers(&env, 1);
+    let random_caller = Address::generate(&env); // not the designated executor
+
+    env.as_contract(&id, || {
+        set_roles(&env, &admin, &approvers, &executor);
+        let pid = GovernanceManager::propose_upgrade(
+            &env,
+            admin.clone(),
+            symbol_short!("hash"),
+            id.clone(),
+            symbol_short!("desc"),
+            1,
+            approvers.clone(),
+            0,
+        )
+        .unwrap();
+        GovernanceManager::approve_proposal(&env, pid, approvers.get(0).unwrap()).unwrap();
+        // Anyone can execute under current behaviour.
+        GovernanceManager::execute_proposal(&env, pid, random_caller.clone()).unwrap();
+        assert_eq!(
+            GovernanceManager::get_proposal(&env, pid).unwrap().status,
+            ProposalStatus::Executed
+        );
+    });
+}


### PR DESCRIPTION
Close #777 

---
## Summary
Governance/upgradeability is the trust layer gating every contract upgrade, but
its tests only covered the nominal happy path. Complex proposal flows —
timelocks, edge votes, and quorum edge cases — were untested, risking unexpected
behavior on fringe cases. This PR adds fuzzed and scenario-based test suites,
simulates governance upgrades end to end, and documents known limitations with
mitigations.
---
## Root cause
The shared governance module (`shared/src/governance.rs`, `GovernanceManager`)
powers upgrades across all contracts, yet only the happy-path lifecycle was
covered (in `contracts/trading/src/test.rs`). There was no coverage for:
- quorum edges (threshold `0` / `> approver count`, empty sets, unanimous,
  post-quorum votes, non-listed approvers),
- timelock edges (zero delay, exact-expiry boundary, one-second-early, overflow),
- state-machine transitions (execute-before-approval, double-execute,
  reject/cancel ordering, terminal-state handling).

The gap is missing negative/edge/fuzz coverage, which left fragile fringe
behaviors unverified and undocumented.
---
## Solution implemented
Two complementary, behavior-preserving test layers plus documentation:
1. **Module-level unit + bounded-fuzz tests** that drive `GovernanceManager`
   directly in isolation.
2. **End-to-end scenario + fuzz tests** that drive the full contract path
   (`require_auth`, role wiring, error mapping, ledger timelock) via the trading
   and messaging clients, including a cross-contract upgrade simulation.
3. **Documentation** of the test inventory and five known limitations, each with
   impact + mitigation. Fringe behaviors are pinned by named tests so any future
   change is caught by CI.

No governance semantics were changed — the issue asks for an extended suite and
documented limitations; altering on-chain behavior is out of scope and would risk
regressions.
---
## Key changes made
- **`shared/tests/governance.rs`** (new): 23 tests — quorum/threshold,
  timelock boundaries, state machine, RBAC; includes two bounded-fuzz sweeps
  (`fuzz_quorum_flips_exactly_at_threshold`, `fuzz_timelock_boundary_enforced`).
- **`integration-tests/tests/governance_flows.rs`** (new): 13 tests — full
  2-of-3 lifecycle, quorum-not-met, timelock boundary, reject/cancel paths,
  concurrent proposals, `simulate_upgrade_across_two_contracts`, and a
  contract-path fuzz sweep.
- **`GOVERNANCE_TESTING.md`** (new): test inventory + known limitations &
  mitigations.
- **`README.md`**: linked the new suites and doc under Testing.
---
## Trade-offs & considerations
- Behavior is intentionally left unchanged; fringe behaviors are **documented**
  (permissionless execution, zero-timelock, unchecked timelock overflow, loose
  `cancel` terminal-state handling, env-level WASM swap) rather than altered.
- A no-role caller triggers `require_role`'s `panic!` (a non-unwinding abort that
  `try_*` cannot catch), so that path is asserted via `#[should_panic]` at the
  module level; the integration test verifies the recoverable
  "approver excluded from proposal subset" branch instead.
- Auto-generated Soroban `test_snapshots/*.json` are included, consistent with
  the repo's existing convention.
---
## Testing steps
```bash
cd Contracts
cargo test -p shared --test governance              # 23 passed
cargo test -p integration-tests --test governance_flows  # 13 passed
cargo test -p trading upgrade                        # 5 passed (regression check)
cargo test --all                                     # full suite

Thank you very much and please if there are any further consideration regarding this issue, please let me know!

Thank you for you time!
