### PR TITLE
fix(staking): unstake now pays pending rewards before removing stake

### DIFF
--- a/Contracts/Cargo.toml
+++ b/Contracts/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "contracts/trading",
+    "contracts/staking-rewards",
     "contracts/social_rewards",
     "contracts/messaging",
     "contracts/academy",

--- a/Contracts/contracts/staking-rewards/src/lib.rs
+++ b/Contracts/contracts/staking-rewards/src/lib.rs
@@ -216,21 +216,39 @@ impl StakingRewardsContract {
             // Penalty stays in the contract (could be sent to a treasury)
         }
 
+        // Pay out any pending rewards before removing stake
+        let pending_rewards = calculate_rewards(&env, &user_stake).unwrap_or(0);
+        if pending_rewards > 0 {
+            let reward_token: Address = env
+                .storage()
+                .instance()
+                .get(&storage_keys::REWARD_TOKEN)
+                .unwrap();
+            soroban_sdk::token::Client::new(&env, &reward_token).transfer(
+                &env.current_contract_address(),
+                &user,
+                &pending_rewards,
+            );
+        }
+
         let staking_token: Address = env
             .storage()
             .instance()
             .get(&storage_keys::STAKE_TOKEN)
             .unwrap();
 
-        let client = soroban_sdk::token::Client::new(&env, &staking_token);
-        client.transfer(&env.current_contract_address(), &user, &principal_to_return);
+        soroban_sdk::token::Client::new(&env, &staking_token).transfer(
+            &env.current_contract_address(),
+            &user,
+            &principal_to_return,
+        );
 
         // Remove stake
         env.storage().persistent().remove(&key);
 
         env.events().publish(
             (symbol_short!("unstake"), user),
-            (principal_to_return, env.ledger().timestamp()),
+            (principal_to_return, pending_rewards, env.ledger().timestamp()),
         );
 
         Ok(principal_to_return)

--- a/Contracts/contracts/staking-rewards/src/test.rs
+++ b/Contracts/contracts/staking-rewards/src/test.rs
@@ -167,3 +167,86 @@ fn test_compounding() {
     assert_eq!(stake_info.amount, 1073);
     assert_eq!(token.balance(&user), 0);
 }
+
+#[test]
+fn test_unstake_pays_pending_rewards() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (staking_token_address, staking_token, staking_token_admin) = create_token(&env, &admin);
+    let (reward_token_address, reward_token, reward_token_admin) = create_token(&env, &admin);
+
+    let contract_id = env.register_contract(None, StakingRewardsContract);
+    let client = StakingRewardsContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &staking_token_address, &reward_token_address);
+
+    staking_token_admin.mint(&user, &1000);
+    reward_token_admin.mint(&contract_id, &100000);
+
+    client.stake(&user, &1000, &0); // 30-day pool, 5% APY
+
+    // Jump 31 days (past lockup) — expected reward: 1000 * 0.05 * (31/365) = 4
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 31 * 24 * 60 * 60,
+        protocol_version: 20,
+        sequence_number: 10,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 31104000,
+        min_persistent_entry_ttl: 31104000,
+        min_temp_entry_ttl: 31104000,
+    });
+
+    let pending = client.get_pending_rewards(&user);
+    assert_eq!(pending, 4);
+
+    // Unstake without claiming first — should receive both principal and rewards
+    let returned = client.unstake(&user);
+    assert_eq!(returned, 1000); // full principal, no penalty
+    assert_eq!(staking_token.balance(&user), 1000);
+    assert_eq!(reward_token.balance(&user), 4); // rewards paid automatically
+}
+
+#[test]
+fn test_unstake_early_pays_pending_rewards() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (staking_token_address, staking_token, staking_token_admin) = create_token(&env, &admin);
+    let (reward_token_address, reward_token, reward_token_admin) = create_token(&env, &admin);
+
+    let contract_id = env.register_contract(None, StakingRewardsContract);
+    let client = StakingRewardsContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &staking_token_address, &reward_token_address);
+
+    staking_token_admin.mint(&user, &1000);
+    reward_token_admin.mint(&contract_id, &100000);
+
+    client.stake(&user, &1000, &0); // 30-day pool
+
+    // Jump 15 days (early withdrawal) — expected reward: 1000 * 0.05 * (15/365) = 2
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 15 * 24 * 60 * 60,
+        protocol_version: 20,
+        sequence_number: 10,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 31104000,
+        min_persistent_entry_ttl: 31104000,
+        min_temp_entry_ttl: 31104000,
+    });
+
+    // Unstake early: 10% penalty on principal, but rewards still paid
+    let returned = client.unstake(&user);
+    assert_eq!(returned, 900); // 1000 - 10% penalty
+    assert_eq!(staking_token.balance(&user), 900);
+    assert_eq!(reward_token.balance(&user), 2); // accrued rewards still paid
+}


### PR DESCRIPTION
## Summary

Fixes #796

The `unstake` function only returned the principal (minus any early withdrawal penalty) and silently discarded any accrued rewards. Users who unstaked without first calling `claim` permanently lost their pending rewards.

## Changes

- **`contracts/staking-rewards/src/lib.rs`** — `unstake` now calls `calculate_rewards()` and transfers pending rewards via the reward token to the user before transferring principal and removing the stake record. The event payload is updated to include `pending_rewards`.
- **`Contracts/Cargo.toml`** — Added `contracts/staking-rewards` to workspace members so the contract is compiled and tested by CI (`cargo test --all`).
- **`contracts/staking-rewards/src/test.rs`** — Two new tests:
  - `test_unstake_pays_pending_rewards`: stakes, advances past the lockup period, unstakes without claiming first, and asserts both full principal and accrued rewards are received.
  - `test_unstake_early_pays_pending_rewards`: stakes, advances before lockup expires, unstakes early, and asserts the penalised principal **and** accrued rewards are both transferred.

## Test results

```
running 5 tests
test test::test_early_withdrawal_penalty ... ok
test test::test_compounding ... ok
test test::test_staking_workflow ... ok
test test::test_unstake_early_pays_pending_rewards ... ok
test test::test_unstake_pays_pending_rewards ... ok

test result: ok. 5 passed; 0 failed
```

Full `cargo test --all` passes with 0 failures across all workspace crates.