### PR TITLE
fix(synthetic-assets): wire real token transfers into CDP operations

### DIFF
--- a/Contracts/contracts/synthetic-assets/src/lib.rs
+++ b/Contracts/contracts/synthetic-assets/src/lib.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Env, Symbol,
 };
+use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
 use shared::events::{
     extended_topics,
     AssetRegisteredEvent, CdpOpenedEvent, CdpClosedEvent,
@@ -37,13 +38,15 @@ pub struct CDP {
 #[contracttype]
 #[derive(Clone)]
 pub struct SyntheticConfig {
-    pub oracle_price: i128,     // price scaled by 1_000_000
-    pub min_cratio: i128,       // scaled by 10000 (15000 = 150%)
-    pub liq_cratio: i128,       // scaled by 10000 (12000 = 120%)
-    pub liq_penalty: i128,      // scaled by 10000 (1300 = 13%)
-    pub stability_fee_bps: i32, // annual fee in bps (200 = 2%)
+    pub oracle_price: i128,       // price scaled by 1_000_000
+    pub min_cratio: i128,         // scaled by 10000 (15000 = 150%)
+    pub liq_cratio: i128,         // scaled by 10000 (12000 = 120%)
+    pub liq_penalty: i128,        // scaled by 10000 (1300 = 13%)
+    pub stability_fee_bps: i32,   // annual fee in bps (200 = 2%)
     pub total_minted: i128,
     pub is_active: bool,
+    pub collateral_token: Address, // token accepted as collateral
+    pub synthetic_token: Address,  // SAC minted/burned for synthetic debt
 }
 
 mod keys {
@@ -64,7 +67,7 @@ impl SyntheticAssetsContract {
         Ok(())
     }
 
-    /// Register a synthetic asset with initial config
+    /// Register a synthetic asset with its collateral and synthetic token addresses
     pub fn register_asset(
         env: Env,
         caller: Address,
@@ -73,6 +76,8 @@ impl SyntheticAssetsContract {
         liq_cratio: i128,
         liq_penalty: i128,
         stability_fee_bps: i32,
+        collateral_token: Address,
+        synthetic_token: Address,
     ) -> Result<(), Error> {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
@@ -85,6 +90,8 @@ impl SyntheticAssetsContract {
             stability_fee_bps,
             total_minted: 0,
             is_active: true,
+            collateral_token,
+            synthetic_token,
         };
         env.storage().persistent().set(&asset_symbol, &config);
 
@@ -116,6 +123,7 @@ impl SyntheticAssetsContract {
             .get(&asset_symbol)
             .ok_or(Error::AssetNotFound)?;
 
+        let old_price = config.oracle_price;
         config.oracle_price = new_price;
         env.storage().persistent().set(&asset_symbol, &config);
 
@@ -123,7 +131,7 @@ impl SyntheticAssetsContract {
             (extended_topics::PRICE_UPDATED,),
             PriceUpdatedEvent {
                 asset_symbol,
-                old_price: config.oracle_price,
+                old_price,
                 new_price,
                 updated_by: caller,
                 timestamp: env.ledger().timestamp(),
@@ -132,7 +140,7 @@ impl SyntheticAssetsContract {
         Ok(())
     }
 
-    /// Open CDP: deposit collateral
+    /// Open CDP: transfer collateral from owner into the contract
     pub fn open_cdp(
         env: Env,
         owner: Address,
@@ -144,6 +152,16 @@ impl SyntheticAssetsContract {
         if collateral_amount <= 0 {
             return Err(Error::InvalidAmount);
         }
+
+        let config: SyntheticConfig = env
+            .storage()
+            .persistent()
+            .get(&asset_symbol)
+            .ok_or(Error::AssetNotFound)?;
+
+        // Pull collateral from owner into the contract
+        TokenClient::new(&env, &config.collateral_token)
+            .transfer(&owner, &env.current_contract_address(), &collateral_amount);
 
         let cdp_key = Self::cdp_key(&owner, &asset_symbol);
         let cdp = CDP {
@@ -193,7 +211,6 @@ impl SyntheticAssetsContract {
             .get(&cdp_key)
             .ok_or(Error::CDPNotFound)?;
 
-        // collateral_ratio = (collateral_amount * 1e6 / oracle_price) / (minted+mint) * 10000
         let new_minted = cdp.minted_amount + mint_amount;
         let collateral_usd = cdp.collateral_amount * 1_000_000 / config.oracle_price;
         let cratio = collateral_usd * 10000 / new_minted;
@@ -209,9 +226,10 @@ impl SyntheticAssetsContract {
         updated_config.total_minted += mint_amount;
 
         env.storage().persistent().set(&cdp_key, &cdp);
-        env.storage()
-            .persistent()
-            .set(&asset_symbol, &updated_config);
+        env.storage().persistent().set(&asset_symbol, &updated_config);
+
+        // Mint synthetic tokens to the owner
+        StellarAssetClient::new(&env, &config.synthetic_token).mint(&owner, &mint_amount);
 
         Ok(new_minted)
     }
@@ -246,9 +264,11 @@ impl SyntheticAssetsContract {
             return Err(Error::InvalidAmount);
         }
 
+        // Burn synthetic tokens from the owner before updating state
+        TokenClient::new(&env, &config.synthetic_token).burn(&owner, &burn_amount);
+
         cdp.minted_amount -= burn_amount;
 
-        // Recalculate cratio
         if cdp.minted_amount > 0 {
             let collateral_usd = cdp.collateral_amount * 1_000_000 / config.oracle_price;
             cdp.collateral_ratio = collateral_usd * 10000 / cdp.minted_amount;
@@ -260,9 +280,7 @@ impl SyntheticAssetsContract {
         updated_config.total_minted -= burn_amount;
 
         env.storage().persistent().set(&cdp_key, &cdp);
-        env.storage()
-            .persistent()
-            .set(&asset_symbol, &updated_config);
+        env.storage().persistent().set(&asset_symbol, &updated_config);
         Ok(())
     }
 
@@ -291,6 +309,10 @@ impl SyntheticAssetsContract {
             .persistent()
             .get(&cdp_key)
             .ok_or(Error::CDPNotFound)?;
+
+        // Pull additional collateral from owner into the contract
+        TokenClient::new(&env, &config.collateral_token)
+            .transfer(&owner, &env.current_contract_address(), &amount);
 
         cdp.collateral_amount += amount;
 
@@ -340,23 +362,29 @@ impl SyntheticAssetsContract {
             return Err(Error::NotLiquidatable);
         }
 
-        // Seize collateral with penalty: seized = debt_usd * (1 + penalty) / collateral_price
         let penalty_collateral = cdp.collateral_amount * config.liq_penalty / 10000;
         let seized = cdp
             .collateral_amount
             .min(cdp.collateral_amount - penalty_collateral);
 
-        let mut updated_config = config;
-        updated_config.total_minted -= cdp.minted_amount;
+        let debt = cdp.minted_amount;
+
+        let mut updated_config = config.clone();
+        updated_config.total_minted -= debt;
 
         cdp.is_active = false;
         cdp.minted_amount = 0;
         cdp.collateral_amount = 0;
 
         env.storage().persistent().set(&cdp_key, &cdp);
-        env.storage()
-            .persistent()
-            .set(&asset_symbol, &updated_config);
+        env.storage().persistent().set(&asset_symbol, &updated_config);
+
+        // Liquidator burns the debt tokens to repay the position
+        TokenClient::new(&env, &config.synthetic_token).burn(&liquidator, &debt);
+
+        // Transfer seized collateral to the liquidator
+        TokenClient::new(&env, &config.collateral_token)
+            .transfer(&env.current_contract_address(), &liquidator, &seized);
 
         env.events().publish(
             (extended_topics::CDP_LIQUIDATED,),
@@ -365,7 +393,7 @@ impl SyntheticAssetsContract {
                 liquidator,
                 asset_symbol,
                 collateral_seized: seized,
-                debt_repaid: cdp.minted_amount,
+                debt_repaid: debt,
                 timestamp: env.ledger().timestamp(),
             },
         );
@@ -373,9 +401,15 @@ impl SyntheticAssetsContract {
         Ok(seized)
     }
 
-    /// Close a CDP with zero debt
+    /// Close a CDP with zero debt and return collateral
     pub fn close_cdp(env: Env, owner: Address, asset_symbol: Symbol) -> Result<i128, Error> {
         owner.require_auth();
+
+        let config: SyntheticConfig = env
+            .storage()
+            .persistent()
+            .get(&asset_symbol)
+            .ok_or(Error::AssetNotFound)?;
 
         let cdp_key = Self::cdp_key(&owner, &asset_symbol);
         let mut cdp: CDP = env
@@ -393,6 +427,10 @@ impl SyntheticAssetsContract {
         cdp.collateral_amount = 0;
 
         env.storage().persistent().set(&cdp_key, &cdp);
+
+        // Return collateral to owner
+        TokenClient::new(&env, &config.collateral_token)
+            .transfer(&env.current_contract_address(), &owner, &returned);
 
         env.events().publish(
             (extended_topics::CDP_CLOSED,),
@@ -441,3 +479,6 @@ impl SyntheticAssetsContract {
         (owner.clone(), asset.clone())
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/Contracts/contracts/synthetic-assets/src/test.rs
+++ b/Contracts/contracts/synthetic-assets/src/test.rs
@@ -1,0 +1,179 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+fn create_collateral_token(
+    env: &Env,
+    admin: &Address,
+) -> (Address, TokenClient<'static>, StellarAssetClient<'static>) {
+    let addr = env.register_stellar_asset_contract(admin.clone());
+    (
+        addr.clone(),
+        TokenClient::new(env, &addr),
+        StellarAssetClient::new(env, &addr),
+    )
+}
+
+#[test]
+fn test_cdp_full_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // Contract must be the admin of the synthetic token so it can mint/burn
+    let contract_id = env.register_contract(None, SyntheticAssetsContract);
+
+    let (coll_addr, coll_client, coll_admin) = create_collateral_token(&env, &admin);
+    let synth_addr = env.register_stellar_asset_contract(contract_id.clone());
+    let synth_client = TokenClient::new(&env, &synth_addr);
+
+    let sc = SyntheticAssetsContractClient::new(&env, &contract_id);
+    sc.initialize(&admin);
+
+    let asset = symbol_short!("sUSD");
+    sc.register_asset(
+        &admin, &asset,
+        &15000,   // min_cratio: 150%
+        &12000,   // liq_cratio: 120%
+        &1300,    // liq_penalty: 13%
+        &50,
+        &coll_addr,
+        &synth_addr,
+    );
+    sc.update_price(&admin, &asset, &1_000_000); // $1.00
+
+    coll_admin.mint(&user, &10000);
+
+    // Open CDP — collateral moves from user to contract
+    sc.open_cdp(&user, &asset, &1500);
+    assert_eq!(coll_client.balance(&user), 8500);
+    assert_eq!(coll_client.balance(&contract_id), 1500);
+
+    // Mint 1000 synthetic tokens
+    // cratio = (1500 * 1e6 / 1e6) * 10000 / 1000 = 15000 (exactly 150%)
+    sc.mint(&user, &asset, &1000);
+    assert_eq!(synth_client.balance(&user), 1000);
+
+    // Burn 500 tokens — balance halves
+    sc.burn(&user, &asset, &500);
+    assert_eq!(synth_client.balance(&user), 500);
+
+    // Burn remaining debt before closing
+    sc.burn(&user, &asset, &500);
+    assert_eq!(synth_client.balance(&user), 0);
+
+    // Close CDP — full collateral returned
+    let returned = sc.close_cdp(&user, &asset);
+    assert_eq!(returned, 1500);
+    assert_eq!(coll_client.balance(&user), 10000);
+    assert_eq!(coll_client.balance(&contract_id), 0);
+
+    let cdp = sc.get_cdp(&user, &asset);
+    assert!(!cdp.is_active);
+}
+
+#[test]
+fn test_add_collateral_transfers_tokens() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, SyntheticAssetsContract);
+    let (coll_addr, coll_client, coll_admin) = create_collateral_token(&env, &admin);
+    let synth_addr = env.register_stellar_asset_contract(contract_id.clone());
+
+    let sc = SyntheticAssetsContractClient::new(&env, &contract_id);
+    sc.initialize(&admin);
+
+    let asset = symbol_short!("sETH");
+    sc.register_asset(&admin, &asset, &15000, &12000, &1300, &50, &coll_addr, &synth_addr);
+    sc.update_price(&admin, &asset, &1_000_000);
+
+    coll_admin.mint(&user, &5000);
+    sc.open_cdp(&user, &asset, &1000);
+    assert_eq!(coll_client.balance(&user), 4000);
+    assert_eq!(coll_client.balance(&contract_id), 1000);
+
+    sc.add_collateral(&user, &asset, &500);
+    assert_eq!(coll_client.balance(&user), 3500);
+    assert_eq!(coll_client.balance(&contract_id), 1500);
+
+    let cdp = sc.get_cdp(&user, &asset);
+    assert_eq!(cdp.collateral_amount, 1500);
+}
+
+#[test]
+fn test_liquidation_transfers_collateral_to_liquidator() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let liquidator = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, SyntheticAssetsContract);
+    let (coll_addr, coll_client, coll_admin) = create_collateral_token(&env, &admin);
+    let synth_addr = env.register_stellar_asset_contract(contract_id.clone());
+    let synth_client = TokenClient::new(&env, &synth_addr);
+
+    let sc = SyntheticAssetsContractClient::new(&env, &contract_id);
+    sc.initialize(&admin);
+
+    let asset = symbol_short!("sBTC");
+    // liq_cratio (16000) > min_cratio (15000) so a position minted at exactly
+    // 150% cratio is already below the liquidation threshold — making it
+    // immediately liquidatable without needing a price feed drop.
+    sc.register_asset(
+        &admin, &asset,
+        &15000,   // min_cratio: 150%
+        &16000,   // liq_cratio: 160% (intentionally > min for test setup)
+        &1300,    // liq_penalty: 13%
+        &50,
+        &coll_addr,
+        &synth_addr,
+    );
+    sc.update_price(&admin, &asset, &1_000_000);
+
+    coll_admin.mint(&user, &10000);
+
+    // Open CDP and mint at exactly 150% → stored cratio = 15000 < liq_cratio (16000)
+    sc.open_cdp(&user, &asset, &1500);
+    sc.mint(&user, &asset, &1000);
+
+    assert_eq!(coll_client.balance(&user), 8500);
+    assert_eq!(synth_client.balance(&user), 1000);
+
+    // Give the liquidator the synthetic tokens they need to repay the debt
+    synth_client.transfer(&user, &liquidator, &1000);
+    assert_eq!(synth_client.balance(&liquidator), 1000);
+
+    // seized = 1500 - (1500 * 1300 / 10000) = 1500 - 195 = 1305
+    let expected_seized = 1500_i128 - (1500_i128 * 1300 / 10000);
+    let liq_coll_before = coll_client.balance(&liquidator);
+
+    let seized = sc.liquidate(&liquidator, &user, &asset);
+
+    assert_eq!(seized, expected_seized);
+    // Liquidator burned debt tokens
+    assert_eq!(synth_client.balance(&liquidator), 0);
+    // Liquidator received the seized collateral
+    assert_eq!(coll_client.balance(&liquidator), liq_coll_before + seized);
+    // Penalty collateral (195) remains in contract
+    assert_eq!(coll_client.balance(&contract_id), 1500 - seized);
+
+    // CDP is wiped
+    let cdp = sc.get_cdp(&user, &asset);
+    assert!(!cdp.is_active);
+    assert_eq!(cdp.minted_amount, 0);
+    assert_eq!(cdp.collateral_amount, 0);
+}


### PR DESCRIPTION
## Summary

Closes #798

- `open_cdp`, `mint`, `burn`, `add_collateral`, `liquidate`, and `close_cdp` were mutating internal accounting only — no tokens ever moved, so positions appeared backed on-chain with zero real asset coverage.
- `SyntheticConfig` now carries `collateral_token` and `synthetic_token` addresses (set at registration) so every CDP operation can reach the right contracts.
- `register_asset` gains two new parameters: the collateral token and the synthetic token (a SAC whose admin is this contract).

## Changes per function

| Function | What was added |
|---|---|
| `open_cdp` | Loads config; transfers collateral from owner → contract |
| `add_collateral` | Transfers additional collateral from owner → contract |
| `mint` | Calls `StellarAssetClient::mint` to issue synthetic tokens to owner |
| `burn` | Calls `TokenClient::burn` to destroy owner's synthetic tokens before reducing debt |
| `liquidate` | Burns liquidator's debt tokens; transfers seized collateral to liquidator |
| `close_cdp` | Loads config; transfers full collateral balance back to owner |

Also fixed a minor bug: `update_price` was emitting the new price in the `old_price` field of the event (variable was overwritten before the event was published).

## Test plan

- [x] `test_cdp_full_lifecycle` — open → mint → burn → burn → close; asserts collateral and synthetic balances at every step
- [x] `test_add_collateral_transfers_tokens` — verifies token moves on `add_collateral`
- [x] `test_liquidation_transfers_collateral_to_liquidator` — verifies liquidator burns debt and receives seized collateral
- [x] `cargo test -p stellara-synthetic-assets` — 3/3 pass, 0 warnings
- [x] `cargo test --all` — full workspace green