### PR TITLE
fix(synthetic-assets): reject non-positive oracle prices (#797)

### DIFF
--- a/Contracts/contracts/synthetic-assets/src/lib.rs
+++ b/Contracts/contracts/synthetic-assets/src/lib.rs
@@ -22,6 +22,7 @@ pub enum Error {
     CDPNotFound = 7,
     NotLiquidatable = 8,
     AssetNotFound = 9,
+    InvalidPrice = 10,
 }
 
 #[contracttype]
@@ -110,12 +111,17 @@ impl SyntheticAssetsContract {
         caller.require_auth();
         Self::require_admin(&env, &caller)?;
 
+        if new_price <= 0 {
+            return Err(Error::InvalidPrice);
+        }
+
         let mut config: SyntheticConfig = env
             .storage()
             .persistent()
             .get(&asset_symbol)
             .ok_or(Error::AssetNotFound)?;
 
+        let old_price = config.oracle_price;
         config.oracle_price = new_price;
         env.storage().persistent().set(&asset_symbol, &config);
 
@@ -123,7 +129,7 @@ impl SyntheticAssetsContract {
             (extended_topics::PRICE_UPDATED,),
             PriceUpdatedEvent {
                 asset_symbol,
-                old_price: config.oracle_price,
+                old_price,
                 new_price,
                 updated_by: caller,
                 timestamp: env.ledger().timestamp(),
@@ -186,6 +192,10 @@ impl SyntheticAssetsContract {
             .get(&asset_symbol)
             .ok_or(Error::AssetNotFound)?;
 
+        if config.oracle_price <= 0 {
+            return Err(Error::InvalidPrice);
+        }
+
         let cdp_key = Self::cdp_key(&owner, &asset_symbol);
         let mut cdp: CDP = env
             .storage()
@@ -234,6 +244,10 @@ impl SyntheticAssetsContract {
             .persistent()
             .get(&asset_symbol)
             .ok_or(Error::AssetNotFound)?;
+
+        if config.oracle_price <= 0 {
+            return Err(Error::InvalidPrice);
+        }
 
         let cdp_key = Self::cdp_key(&owner, &asset_symbol);
         let mut cdp: CDP = env
@@ -284,6 +298,10 @@ impl SyntheticAssetsContract {
             .persistent()
             .get(&asset_symbol)
             .ok_or(Error::AssetNotFound)?;
+
+        if config.oracle_price <= 0 {
+            return Err(Error::InvalidPrice);
+        }
 
         let cdp_key = Self::cdp_key(&owner, &asset_symbol);
         let mut cdp: CDP = env
@@ -439,5 +457,87 @@ impl SyntheticAssetsContract {
 
     fn cdp_key(owner: &Address, asset: &Symbol) -> (Address, Symbol) {
         (owner.clone(), asset.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, SyntheticAssetsContractClient<'static>, Address, Symbol) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SyntheticAssetsContract);
+        let client: SyntheticAssetsContractClient<'static> =
+            unsafe { core::mem::transmute(SyntheticAssetsContractClient::new(&env, &id)) };
+        let admin = Address::generate(&env);
+        let asset = symbol_short!("sBTC");
+        client.initialize(&admin);
+        client.register_asset(&admin, &asset, &15000, &12000, &1300, &200);
+        (env, client, admin, asset)
+    }
+
+    #[test]
+    fn test_update_price_rejects_zero() {
+        let (_env, client, admin, asset) = setup();
+        assert_eq!(
+            client.try_update_price(&admin, &asset, &0),
+            Err(Ok(Error::InvalidPrice))
+        );
+    }
+
+    #[test]
+    fn test_update_price_rejects_negative() {
+        let (_env, client, admin, asset) = setup();
+        assert_eq!(
+            client.try_update_price(&admin, &asset, &-1),
+            Err(Ok(Error::InvalidPrice))
+        );
+    }
+
+    #[test]
+    fn test_update_price_accepts_positive() {
+        let (_env, client, admin, asset) = setup();
+        client.update_price(&admin, &asset, &1_000_000);
+        assert_eq!(client.get_config(&asset).oracle_price, 1_000_000);
+    }
+
+    #[test]
+    fn test_mint_blocked_on_zero_price() {
+        let (env, client, admin, asset) = setup();
+        let owner = Address::generate(&env);
+        client.open_cdp(&owner, &asset, &10_000_000);
+        // oracle_price is still 0 after register_asset
+        assert_eq!(
+            client.try_mint(&owner, &asset, &1_000),
+            Err(Ok(Error::InvalidPrice))
+        );
+        // valid price allows mint
+        client.update_price(&admin, &asset, &50_000_000);
+        assert!(client.try_mint(&owner, &asset, &1_000).is_ok());
+    }
+
+    #[test]
+    fn test_burn_blocked_on_zero_price() {
+        let (env, client, admin, asset) = setup();
+        let owner = Address::generate(&env);
+        client.open_cdp(&owner, &asset, &10_000_000);
+        // cannot set price to 0 via update_price anymore; verify burn works with valid price
+        client.update_price(&admin, &asset, &50_000_000);
+        client.mint(&owner, &asset, &100);
+        assert!(client.try_burn(&owner, &asset, &100).is_ok());
+    }
+
+    #[test]
+    fn test_add_collateral_blocked_on_zero_price() {
+        let (env, client, _admin, asset) = setup();
+        let owner = Address::generate(&env);
+        client.open_cdp(&owner, &asset, &10_000_000);
+        // oracle_price still 0
+        assert_eq!(
+            client.try_add_collateral(&owner, &asset, &1_000_000),
+            Err(Ok(Error::InvalidPrice))
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #797

Registered assets start with `oracle_price: 0` and `update_price` previously accepted any value, allowing zero or negative prices. Division by `oracle_price` in `mint`, `burn`, and `add_collateral` would panic or produce broken CDP math.

## Changes

- New error: `InvalidPrice = 10` added to `Error` enum
- - `update_price`: rejects `new_price <= 0` with `InvalidPrice`
- - `mint` / `burn` / `add_collateral`: guard `oracle_price <= 0` before any division
- - Event bug fix: `update_price` was emitting `old_price: config.oracle_price` after the mutation (always logged the new value as old); now captures `old_price` before writing
## Tests

6 new unit tests in `src/lib.rs`:

| Test | Covers |
|------|--------|
| `test_update_price_rejects_zero` | zero price rejected |
| `test_update_price_rejects_negative` | negative price rejected |
| `test_update_price_accepts_positive` | valid price accepted and stored |
| `test_mint_blocked_on_zero_price` | mint blocked at zero, unblocked after valid price |
| `test_burn_blocked_on_zero_price` | burn succeeds with valid price |
| `test_add_collateral_blocked_on_zero_price` | add_collateral blocked at zero price |

## CI

`cargo test --all` passes — 0 failures across the full workspace.