### PR TITLE
fix: store reward token in init and transfer tokens before emitting reward event

### DIFF
--- a/Contracts/contracts/social_rewards/src/lib.rs
+++ b/Contracts/contracts/social_rewards/src/lib.rs
@@ -64,15 +64,28 @@ impl From<soroban_sdk::Error> for RewardError {
     }
 }
 
+// Storage key for the reward token address
+const REWARD_TOKEN_KEY: &str = "rew_tok";
+
+/// Returns the SEP-41 token client balance for `account`.
+fn token_balance(env: &Env, token: &Address, account: &Address) -> i128 {
+    soroban_sdk::token::Client::new(env, token).balance(account)
+}
+
+/// Transfers `amount` of the reward token from `from` to `to`.
+fn token_transfer(env: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+    soroban_sdk::token::Client::new(env, token).transfer(from, to, &amount);
+}
+
 #[contractimpl]
 impl SocialRewardsContract {
-    /// Initialize the social rewards contract
-    pub fn init(env: Env, admin: Address) -> Result<(), RewardError> {
+    /// Initialize the social rewards contract.
+    /// `reward_token` is the SEP-41 token used for reward payouts.
+    pub fn init(env: Env, admin: Address, reward_token: Address) -> Result<(), RewardError> {
         let init_key = symbol_short!("init");
         if env.storage().persistent().has(&init_key) {
             return Err(RewardError::Unauthorized);
         }
-
         env.storage().persistent().set(&init_key, &true);
         env.storage()
             .persistent()
@@ -80,7 +93,9 @@ impl SocialRewardsContract {
         env.storage()
             .persistent()
             .set(&symbol_short!("eng_cnt"), &0u64);
-
+        env.storage()
+            .persistent()
+            .set(&Symbol::new(&env, REWARD_TOKEN_KEY), &reward_token);
         Ok(())
     }
 
@@ -131,14 +146,15 @@ impl SocialRewardsContract {
             timestamp: current_timestamp,
             metadata,
         };
-
         env.events()
             .publish((symbol_short!("eng_rec"),), engagement_event);
 
         Ok(next_id)
     }
 
-    /// Distribute reward for engagement
+    /// Distribute reward for an engagement.
+    /// Verifies the admin, checks the reward pool balance, transfers tokens to
+    /// the user, and only then emits the RewardDistributed event.
     pub fn distribute_reward(
         env: Env,
         admin: Address,
@@ -158,7 +174,6 @@ impl SocialRewardsContract {
             .persistent()
             .get(&symbol_short!("admin"))
             .ok_or(RewardError::Unauthorized)?;
-
         if admin != stored_admin {
             return Err(RewardError::Unauthorized);
         }
@@ -175,16 +190,31 @@ impl SocialRewardsContract {
             .get(&engagement_key)
             .ok_or(RewardError::EngagementNotFound)?;
 
+        // Load reward token
+        let reward_token: Address = env
+            .storage()
+            .persistent()
+            .get(&Symbol::new(&env, REWARD_TOKEN_KEY))
+            .ok_or(RewardError::NotInitialized)?;
+
+        // Check reward pool balance (admin holds the reward pool)
+        let pool_balance = token_balance(&env, &reward_token, &admin);
+        if pool_balance < reward_amount {
+            return Err(RewardError::InsufficientBalance);
+        }
+
+        // Transfer tokens to the user before emitting event
+        token_transfer(&env, &reward_token, &admin, &engagement.user, reward_amount);
+
         let current_timestamp = env.ledger().timestamp();
 
-        // Emit RewardDistributed event
+        // Emit RewardDistributed event only after successful transfer
         let reward_event = RewardDistributed {
             engagement_id,
             user: engagement.user,
             reward_amount,
             timestamp: current_timestamp,
         };
-
         env.events()
             .publish((symbol_short!("rew_dist"),), reward_event);
 
@@ -196,7 +226,6 @@ impl SocialRewardsContract {
         if amount <= 0 {
             return Err(RewardError::InvalidAmount);
         }
-
         let init_key = symbol_short!("init");
         if !env.storage().persistent().has(&init_key) {
             return Err(RewardError::NotInitialized);
@@ -207,7 +236,123 @@ impl SocialRewardsContract {
 
         // Record engagement as generic reward activity
         let _engagement_id = Self::record_engagement(env, user, reward_type, amount)?;
-
         Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Address, Env,
+    };
+
+    fn create_token(
+        env: &Env,
+        admin: &Address,
+    ) -> (Address, TokenClient<'static>, StellarAssetClient<'static>) {
+        let address = env.register_stellar_asset_contract(admin.clone());
+        (
+            address.clone(),
+            TokenClient::new(env, &address),
+            StellarAssetClient::new(env, &address),
+        )
+    }
+
+    fn setup() -> (Env, Address, Address, Address, TokenClient<'static>, StellarAssetClient<'static>, SocialRewardsContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: 1_000_000,
+            protocol_version: 20,
+            sequence_number: 1,
+            network_id: [0u8; 32],
+            base_reserve: 10,
+            max_entry_ttl: 31104000,
+            min_persistent_entry_ttl: 31104000,
+            min_temp_entry_ttl: 31104000,
+        });
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let (token_addr, token_client, token_admin) = create_token(&env, &admin);
+
+        // Mint 10_000 reward tokens to admin (the reward pool)
+        token_admin.mint(&admin, &10_000);
+
+        let contract_id = env.register_contract(None, SocialRewardsContract);
+        let client = SocialRewardsContractClient::new(&env, &contract_id);
+        client.init(&admin, &token_addr);
+
+        (env, admin, user, token_addr, token_client, token_admin, client)
+    }
+
+    #[test]
+    fn test_init_stores_reward_token() {
+        // Should not panic — init sets the reward token
+        let (_env, _admin, _user, _token_addr, _token, _token_admin, _client) = setup();
+    }
+
+    #[test]
+    fn test_distribute_reward_transfers_tokens() {
+        let (_env, admin, user, _token_addr, token, _token_admin, client) = setup();
+
+        // Record an engagement for the user
+        let eng_id = client.record_engagement(
+            &user,
+            &Symbol::new(&_env, "like"),
+            &100,
+        );
+
+        let admin_before = token.balance(&admin);
+        let user_before = token.balance(&user);
+
+        // Distribute 500 tokens
+        client.distribute_reward(&admin, &eng_id, &500);
+
+        assert_eq!(token.balance(&admin), admin_before - 500);
+        assert_eq!(token.balance(&user), user_before + 500);
+    }
+
+    #[test]
+    fn test_distribute_reward_emits_event_after_transfer() {
+        let (_env, admin, user, _token_addr, token, _token_admin, client) = setup();
+
+        let eng_id = client.record_engagement(&user, &Symbol::new(&_env, "post"), &50);
+
+        client.distribute_reward(&admin, &eng_id, &200);
+
+        // Balances confirm tokens actually moved
+        assert_eq!(token.balance(&user), 200);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_distribute_reward_fails_on_insufficient_balance() {
+        let (_env, admin, user, _token_addr, _token, _token_admin, client) = setup();
+
+        let eng_id = client.record_engagement(&user, &Symbol::new(&_env, "share"), &10);
+
+        // Try to distribute more than admin holds (10_000 minted)
+        client.distribute_reward(&admin, &eng_id, &100_000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_distribute_reward_fails_for_invalid_amount() {
+        let (_env, admin, user, _token_addr, _token, _token_admin, client) = setup();
+
+        let eng_id = client.record_engagement(&user, &Symbol::new(&_env, "share"), &10);
+        client.distribute_reward(&admin, &eng_id, &0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_distribute_reward_fails_for_unknown_engagement() {
+        let (_env, admin, _user, _token_addr, _token, _token_admin, client) = setup();
+        client.distribute_reward(&admin, &999, &100);
     }
 }


### PR DESCRIPTION
## Summary

distribute_reward was emitting RewardDistributed events without ever storing a reward token or transferring any assets. On-chain events claimed rewards were distributed when no funds moved.

## Changes

- init now accepts a eward_token: Address parameter and persists it in contract storage
- distribute_reward loads the stored reward token, checks the admin pool balance against InsufficientBalance, performs the token transfer via soroban_sdk::token::Client, and only emits the event after a successful transfer
- Added #[cfg(test)] module covering token transfer, insufficient balance, invalid amount, and unknown engagement cases

closes #791