### PR TITLE
fix: prevent arithmetic overflow in staking reward calculations

### DIFF
--- a/Contracts/contracts/staking-rewards/src/lib.rs
+++ b/Contracts/contracts/staking-rewards/src/lib.rs
@@ -26,6 +26,7 @@ pub enum ContractError {
     InsufficientBalance = 6,
     StillLocked = 7,
     NothingToClaim = 8,
+    ArithmeticOverflow = 9,
 }
 
 #[contracttype]
@@ -133,7 +134,10 @@ impl StakingRewardsContract {
 
         // For simplicity, if they already have a stake, they must unstake first or we just update
         // In this implementation, we allow adding to stake but reset the timer for the whole amount
-        user_stake.amount += amount;
+        user_stake.amount = user_stake
+            .amount
+            .checked_add(amount)
+            .ok_or(ContractError::ArithmeticOverflow)?;
         user_stake.pool_id = pool_id;
         user_stake.start_timestamp = env.ledger().timestamp();
         user_stake.last_claim_timestamp = env.ledger().timestamp();
@@ -203,15 +207,20 @@ impl StakingRewardsContract {
 
         let pool = pools.get_unchecked(user_stake.pool_id);
         let now = env.ledger().timestamp();
-        let elapsed = now - user_stake.start_timestamp;
+        let elapsed = now.saturating_sub(user_stake.start_timestamp);
 
         let mut principal_to_return = user_stake.amount;
 
         // Apply early withdrawal penalty if lockup hasn't expired
         if elapsed < pool.lockup_seconds {
-            let penalty_bps = 1000; // 10% penalty
-            let penalty_amount = (principal_to_return * penalty_bps as i128) / 10000;
-            principal_to_return -= penalty_amount;
+            let penalty_bps: i128 = 1000; // 10% penalty
+            let penalty_amount = principal_to_return
+                .checked_mul(penalty_bps)
+                .and_then(|v| v.checked_div(10000))
+                .ok_or(ContractError::ArithmeticOverflow)?;
+            principal_to_return = principal_to_return
+                .checked_sub(penalty_amount)
+                .ok_or(ContractError::ArithmeticOverflow)?;
 
             // Penalty stays in the contract (could be sent to a treasury)
         }
@@ -294,7 +303,10 @@ impl StakingRewardsContract {
             return Err(ContractError::Unauthorized); // Or a more specific error
         }
 
-        user_stake.amount += reward_amount;
+        user_stake.amount = user_stake
+            .amount
+            .checked_add(reward_amount)
+            .ok_or(ContractError::ArithmeticOverflow)?;
         user_stake.last_claim_timestamp = env.ledger().timestamp();
         env.storage().persistent().set(&key, &user_stake);
 
@@ -335,20 +347,30 @@ fn calculate_rewards(env: &Env, user_stake: &UserStake) -> Result<i128, Contract
 
     let pool = pools.get(user_stake.pool_id).unwrap();
     let now = env.ledger().timestamp();
-    let elapsed_seconds = now - user_stake.last_claim_timestamp;
+    let elapsed_seconds = now.saturating_sub(user_stake.last_claim_timestamp);
 
     if elapsed_seconds == 0 {
         return Ok(0);
     }
 
     // Reward = Principal * APY * (elapsed / seconds_in_year)
-    // APY is in basis points
+    // APY is in basis points (e.g. 500 = 5%)
     let seconds_in_year: u64 = 365 * 24 * 60 * 60;
 
-    // Scale precision for calculation: (amount * apy * seconds) / (10000 * seconds_in_year)
-    // Using i128 to prevent overflow in Intermediate calculation
-    let reward = (user_stake.amount * pool.apy_bps as i128 * elapsed_seconds as i128)
-        / (10000i128 * seconds_in_year as i128);
+    // Checked arithmetic prevents silent overflow on large stakes, high APY, or long durations
+    let amount_times_apy = user_stake
+        .amount
+        .checked_mul(pool.apy_bps as i128)
+        .ok_or(ContractError::ArithmeticOverflow)?;
+    let numerator = amount_times_apy
+        .checked_mul(elapsed_seconds as i128)
+        .ok_or(ContractError::ArithmeticOverflow)?;
+    let denominator = 10000_i128
+        .checked_mul(seconds_in_year as i128)
+        .ok_or(ContractError::ArithmeticOverflow)?;
+    let reward = numerator
+        .checked_div(denominator)
+        .ok_or(ContractError::ArithmeticOverflow)?;
 
     Ok(reward)
 }

--- a/Contracts/contracts/staking-rewards/src/test.rs
+++ b/Contracts/contracts/staking-rewards/src/test.rs
@@ -211,3 +211,70 @@ fn test_compounding() {
     assert_eq!(stake_info.amount, 1073);
     assert_eq!(token.balance(&user), 0);
 }
+
+#[test]
+#[should_panic]
+fn test_overflow_protection_in_reward_calculation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (staking_token_address, _staking_token, staking_token_admin) = create_token(&env, &admin);
+    let (reward_token_address, _reward_token, _reward_token_admin) = create_token(&env, &admin);
+
+    let contract_id = env.register_contract(None, StakingRewardsContract);
+    let client = StakingRewardsContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &staking_token_address, &reward_token_address);
+
+    // Stake an amount large enough to overflow in reward calculation.
+    // With pool 0 (apy_bps=500) and 1 year elapsed:
+    //   amount * 500 * 31_536_000 overflows i128 when amount > ~1.08e28.
+    // Use 10^29 to guarantee the second checked_mul returns None.
+    let large_amount: i128 = 100_000_000_000_000_000_000_000_000_000_i128;
+    staking_token_admin.mint(&user, &large_amount);
+    client.stake(&user, &large_amount, &0);
+
+    // Advance one year
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 365 * 24 * 60 * 60,
+        protocol_version: 20,
+        sequence_number: 10,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 31104000,
+        min_persistent_entry_ttl: 31104000,
+        min_temp_entry_ttl: 31104000,
+    });
+
+    // Claiming should panic (ArithmeticOverflow) because the numerator exceeds i128::MAX
+    client.claim(&user);
+}
+
+#[test]
+#[should_panic]
+fn test_overflow_protection_on_early_withdrawal_penalty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let (staking_token_address, _staking_token, staking_token_admin) = create_token(&env, &admin);
+    let (reward_token_address, _reward_token, _reward_token_admin) = create_token(&env, &admin);
+
+    let contract_id = env.register_contract(None, StakingRewardsContract);
+    let client = StakingRewardsContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &staking_token_address, &reward_token_address);
+
+    // Stake i128::MAX tokens; adding to an empty stake (0 + MAX) does not overflow.
+    staking_token_admin.mint(&user, &i128::MAX);
+    client.stake(&user, &i128::MAX, &0);
+
+    // Immediately unstake without advancing time → early withdrawal applies.
+    // Penalty calc: i128::MAX * 1_000 overflows i128 → should panic (ArithmeticOverflow).
+    client.unstake(&user);
+}


### PR DESCRIPTION
Add checked arithmetic throughout the staking rewards contract to guard against silent integer overflow on large stakes, high APY values, or long elapsed periods.

Changes:
- Added ArithmeticOverflow = 9 variant to ContractError
- stake(): replaced unchecked addition with checked_add
- compound(): replaced unchecked addition with checked_add
- unstake(): switched timestamp diff to saturating_sub; penalty calc uses checked arithmetic
- calculate_rewards(): switched timestamp diff to saturating_sub; reward uses checked_mul and checked_div
- Added two boundary tests that trigger overflow cases

closes #793