### PR TITLE
feat(webhook): SSRF protection, HMAC signing, backoff retry & dead-letter (#759)

### DIFF
--- a/Backend/src/database/migrations/1784000000000-AddWebhookConsumerDeliveryColumns.ts
+++ b/Backend/src/database/migrations/1784000000000-AddWebhookConsumerDeliveryColumns.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds delivery-tracking columns to webhook_consumers, supporting the webhook
+ * delivery retry/dead-letter mechanism:
+ *   - deliveryAttempts: retry count for the most recent in-flight event
+ *   - lastError: last error message recorded on a failed/dead-lettered delivery
+ */
+export class AddWebhookConsumerDeliveryColumns1784000000000
+  implements MigrationInterface
+{
+  name = 'AddWebhookConsumerDeliveryColumns1784000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhook_consumers" ADD COLUMN IF NOT EXISTS "deliveryAttempts" integer NOT NULL DEFAULT '0'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "webhook_consumers" ADD COLUMN IF NOT EXISTS "lastError" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhook_consumers" DROP COLUMN IF EXISTS "lastError"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "webhook_consumers" DROP COLUMN IF EXISTS "deliveryAttempts"`,
+    );
+  }
+}

--- a/Backend/src/stellar-monitor/dto/create-consumer.dto.ts
+++ b/Backend/src/stellar-monitor/dto/create-consumer.dto.ts
@@ -9,6 +9,7 @@ import {
   Length,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { IsSafeWebhookUrl } from '../validators/is-safe-webhook-url.validator';
 
 export class CreateConsumerDto {
   @IsString()
@@ -16,6 +17,7 @@ export class CreateConsumerDto {
   name: string;
 
   @IsUrl({ require_protocol: true })
+  @IsSafeWebhookUrl()
   @Length(1, 500)
   url: string;
 

--- a/Backend/src/stellar-monitor/entities/webhook-consumer.entity.ts
+++ b/Backend/src/stellar-monitor/entities/webhook-consumer.entity.ts
@@ -61,4 +61,13 @@ export class WebhookConsumer {
 
   @Column({ default: 0 })
   failedDeliveries: number;
+
+  // Number of delivery attempts made for the most recent in-flight event.
+  // Reset to 0 on a successful delivery; incremented on every retry.
+  @Column({ default: 0 })
+  deliveryAttempts: number;
+
+  // Last error message recorded for a failed/dead-lettered delivery.
+  @Column({ type: 'text', nullable: true })
+  lastError?: string;
 }

--- a/Backend/src/stellar-monitor/services/consumer-management.service.spec.ts
+++ b/Backend/src/stellar-monitor/services/consumer-management.service.spec.ts
@@ -9,6 +9,12 @@ describe('ConsumerManagementService', () => {
   let service: ConsumerManagementService;
   let repository: Repository<WebhookConsumer>;
 
+  const mockQueryBuilder = {
+    where: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+  };
+
   const mockConsumerRepository = {
     create: jest.fn(),
     save: jest.fn(),
@@ -16,6 +22,7 @@ describe('ConsumerManagementService', () => {
     find: jest.fn(),
     remove: jest.fn(),
     count: jest.fn(),
+    createQueryBuilder: jest.fn(() => mockQueryBuilder),
   };
 
   beforeEach(async () => {
@@ -72,12 +79,13 @@ describe('ConsumerManagementService', () => {
   describe('getAllConsumers', () => {
     it('should return all consumers', async () => {
       const consumers = [new WebhookConsumer(), new WebhookConsumer()];
-      mockConsumerRepository.find.mockResolvedValue(consumers);
+      mockQueryBuilder.getMany.mockResolvedValue(consumers);
 
       const result = await service.getAllConsumers();
 
       expect(result).toEqual(consumers);
-      expect(mockConsumerRepository.find).toHaveBeenCalled();
+      expect(mockConsumerRepository.createQueryBuilder).toHaveBeenCalled();
+      expect(mockQueryBuilder.getMany).toHaveBeenCalled();
     });
   });
 });

--- a/Backend/src/stellar-monitor/services/consumer-management.service.ts
+++ b/Backend/src/stellar-monitor/services/consumer-management.service.ts
@@ -185,6 +185,21 @@ export class ConsumerManagementService {
     return this.consumerRepository.save(consumer);
   }
 
+  /**
+   * Records delivery progress (retry attempts and last error) on a consumer.
+   * Pass `attempts = 0` and `lastError = null` to reset after a success.
+   */
+  async recordDeliveryProgress(
+    consumerId: string,
+    attempts: number,
+    lastError: string | null,
+  ): Promise<WebhookConsumer> {
+    const consumer = await this.getConsumerById(consumerId);
+    consumer.deliveryAttempts = attempts;
+    consumer.lastError = lastError ?? undefined;
+    return this.consumerRepository.save(consumer);
+  }
+
   async getConsumerHealthStats(consumerId: string): Promise<{
     successRate: number;
     recentFailures: number;

--- a/Backend/src/stellar-monitor/services/webhook-delivery.service.spec.ts
+++ b/Backend/src/stellar-monitor/services/webhook-delivery.service.spec.ts
@@ -1,0 +1,283 @@
+import { createHmac } from 'crypto';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { ConsumerManagementService } from './consumer-management.service';
+import { EventStorageService } from './event-storage.service';
+import { WebhookConsumer } from '../entities/webhook-consumer.entity';
+import { StellarEvent } from '../entities/stellar-event.entity';
+import { DeliveryStatus, EventType } from '../types/stellar.types';
+import { isPrivateIp, validateWebhookUrl } from '../utils/ssrf.util';
+import { IsSafeWebhookUrlConstraint } from '../validators/is-safe-webhook-url.validator';
+
+describe('SSRF protection (ssrf.util)', () => {
+  describe('isPrivateIp', () => {
+    it.each([
+      '127.0.0.1',
+      '10.0.0.5',
+      '192.168.1.1',
+      '169.254.169.254', // cloud metadata endpoint
+      '172.16.0.1',
+      '172.31.255.255',
+      '100.64.0.1', // CGNAT
+      '0.0.0.0',
+      '::1',
+      'fd00::1',
+      'fe80::1',
+    ])('rejects private/internal address %s', (ip) => {
+      expect(isPrivateIp(ip)).toBe(true);
+    });
+
+    it.each(['8.8.8.8', '1.1.1.1', '93.184.216.34', '2606:2800:220:1::'])(
+      'accepts public address %s',
+      (ip) => {
+        expect(isPrivateIp(ip)).toBe(false);
+      },
+    );
+  });
+
+  describe('validateWebhookUrl', () => {
+    it.each([
+      'http://127.0.0.1/hook',
+      'http://localhost:3000/hook',
+      'http://10.0.0.5/hook',
+      'http://192.168.1.10/hook',
+      'http://169.254.169.254/latest/meta-data',
+      'http://[::1]/hook',
+    ])('rejects private URL %s', async (url) => {
+      await expect(validateWebhookUrl(url)).rejects.toThrow();
+    });
+
+    it('rejects non-http(s) schemes', async () => {
+      await expect(validateWebhookUrl('ftp://example.com')).rejects.toThrow();
+      await expect(
+        validateWebhookUrl('file:///etc/passwd'),
+      ).rejects.toThrow();
+    });
+
+    it('rejects malformed URLs', async () => {
+      await expect(validateWebhookUrl('not a url')).rejects.toThrow();
+    });
+
+    it('accepts a public IP literal URL', async () => {
+      await expect(
+        validateWebhookUrl('https://8.8.8.8/hook'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('IsSafeWebhookUrlConstraint', () => {
+    const c = new IsSafeWebhookUrlConstraint();
+
+    it('rejects private/localhost/non-http URLs', () => {
+      expect(c.validate('http://127.0.0.1/x')).toBe(false);
+      expect(c.validate('http://localhost/x')).toBe(false);
+      expect(c.validate('http://192.168.0.1/x')).toBe(false);
+      expect(c.validate('ftp://example.com')).toBe(false);
+      expect(c.validate('garbage')).toBe(false);
+      expect(c.validate(123 as unknown as string)).toBe(false);
+    });
+
+    it('accepts public http(s) URLs', () => {
+      expect(c.validate('https://example.com/webhook')).toBe(true);
+      expect(c.validate('https://8.8.8.8/webhook')).toBe(true);
+    });
+  });
+});
+
+describe('WebhookDeliveryService', () => {
+  let service: WebhookDeliveryService;
+  let consumerService: jest.Mocked<Partial<ConsumerManagementService>>;
+  let eventService: jest.Mocked<Partial<EventStorageService>>;
+
+  const makeConsumer = (over: Partial<WebhookConsumer> = {}): WebhookConsumer =>
+    ({
+      id: 'consumer-1',
+      name: 'c1',
+      url: 'https://example.com/webhook',
+      secret: 'topsecret',
+      isActive: true,
+      maxRetries: 5,
+      timeoutMs: 5000,
+      totalDeliveries: 0,
+      failedDeliveries: 0,
+      deliveryAttempts: 0,
+      ...over,
+    }) as WebhookConsumer;
+
+  const makeEvent = (over: Partial<StellarEvent> = {}): StellarEvent =>
+    ({
+      id: 'event-1',
+      eventType: EventType.PAYMENT,
+      ledgerSequence: 1,
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+      transactionHash: 'hash',
+      sourceAccount: 'acct',
+      payload: { a: 1 },
+      deliveryAttempts: 0,
+      ...over,
+    }) as StellarEvent;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    consumerService = {
+      getActiveConsumers: jest.fn().mockResolvedValue([]),
+      getConsumerById: jest.fn(),
+      updateDeliveryStats: jest.fn().mockResolvedValue(undefined),
+      recordDeliveryProgress: jest.fn().mockResolvedValue(undefined),
+    };
+    eventService = {
+      updateEventStatus: jest.fn().mockResolvedValue(undefined),
+      markEventAsProcessed: jest.fn().mockResolvedValue(undefined),
+      getPendingEvents: jest.fn().mockResolvedValue([]),
+    };
+    service = new WebhookDeliveryService(
+      consumerService as ConsumerManagementService,
+      eventService as EventStorageService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe('signature generation', () => {
+    it('attaches an X-Stellara-Signature HMAC-SHA256 header', async () => {
+      const consumer = makeConsumer();
+      const event = makeEvent();
+      const post = jest.fn().mockResolvedValue({ status: 200 });
+      (service as any).httpClient = { post };
+
+      const result = await (service as any).attemptDelivery(event, consumer, 1);
+
+      expect(result.success).toBe(true);
+      const [url, body, config] = post.mock.calls[0];
+      expect(url).toBe(consumer.url);
+
+      const expected = createHmac('sha256', consumer.secret)
+        .update(body as string)
+        .digest('hex');
+      expect(config.headers[WebhookDeliveryService.SIGNATURE_HEADER]).toBe(
+        expected,
+      );
+      expect(config.headers['X-Delivery-Attempt']).toBe('1');
+      expect(config.headers['X-Idempotency-Key']).toBe('event-1:consumer-1');
+    });
+
+    it('omits the signature header when consumer has no secret', async () => {
+      const consumer = makeConsumer({ secret: undefined });
+      const post = jest.fn().mockResolvedValue({ status: 200 });
+      (service as any).httpClient = { post };
+
+      await (service as any).attemptDelivery(makeEvent(), consumer, 1);
+
+      const config = post.mock.calls[0][2];
+      expect(
+        config.headers[WebhookDeliveryService.SIGNATURE_HEADER],
+      ).toBeUndefined();
+    });
+
+    it('generateSignature is deterministic and matches crypto', () => {
+      const sig = (service as any).generateSignature('payload', 'secret');
+      expect(sig).toBe(
+        createHmac('sha256', 'secret').update('payload').digest('hex'),
+      );
+    });
+  });
+
+  describe('backoff schedule', () => {
+    it('follows 1s, 5s, 30s, 5m, 30m', () => {
+      const delays = [1, 2, 3, 4, 5].map((a) =>
+        (service as any).calculateBackoffDelay(a),
+      );
+      expect(delays).toEqual([1000, 5000, 30000, 300000, 1800000]);
+    });
+  });
+
+  describe('retry escalation', () => {
+    const failure = { success: false, errorMessage: 'boom' };
+
+    it('schedules a retry with backoff when under the attempt cap', async () => {
+      const consumer = makeConsumer();
+      const event = makeEvent();
+
+      await (service as any).handleFailedDelivery(event, consumer, failure, 1);
+
+      // Records the attempt + error on the consumer, marks event RETRYING.
+      expect(consumerService.recordDeliveryProgress).toHaveBeenCalledWith(
+        'consumer-1',
+        1,
+        'boom',
+      );
+      expect(eventService.updateEventStatus).toHaveBeenCalledWith(
+        'event-1',
+        DeliveryStatus.RETRYING,
+        'consumer-1',
+        'boom',
+      );
+      expect(service.getQueueSize()).toBe(0);
+
+      // Hold the queue so the re-queued item is observable (otherwise
+      // processQueue drains it immediately).
+      (service as any).isProcessingQueue = true;
+
+      // Nothing re-queued before the 1s backoff elapses...
+      jest.advanceTimersByTime(999);
+      expect(service.getQueueSize()).toBe(0);
+      // ...and re-queued with an incremented attempt afterwards.
+      jest.advanceTimersByTime(1);
+      expect(service.getQueueSize()).toBe(1);
+      expect((service as any).deliveryQueue[0].attempt).toBe(2);
+    });
+
+    it('moves to dead-letter after the 5th failed attempt', async () => {
+      const consumer = makeConsumer();
+      const event = makeEvent();
+
+      await (service as any).handleFailedDelivery(event, consumer, failure, 5);
+
+      expect(eventService.updateEventStatus).toHaveBeenCalledWith(
+        'event-1',
+        DeliveryStatus.DEAD_LETTER,
+        'consumer-1',
+        'boom',
+      );
+      // No retry scheduled.
+      jest.advanceTimersByTime(WebhookDeliveryService.RETRY_DELAYS_MS[4]);
+      expect(service.getQueueSize()).toBe(0);
+    });
+
+    it('dead-letters immediately when the URL is unsafe (SSRF)', async () => {
+      const consumer = makeConsumer({ url: 'http://169.254.169.254/' });
+      consumerService.getConsumerById = jest.fn().mockResolvedValue(consumer);
+      const event = makeEvent();
+
+      await (service as any).deliverEventToConsumer(event, consumer, 1);
+
+      expect(eventService.updateEventStatus).toHaveBeenCalledWith(
+        'event-1',
+        DeliveryStatus.DEAD_LETTER,
+        'consumer-1',
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('idempotency / deduplication', () => {
+    it('does not deliver the same event to the same consumer twice', async () => {
+      const consumer = makeConsumer();
+      consumerService.getConsumerById = jest.fn().mockResolvedValue(consumer);
+      consumerService.getActiveConsumers = jest
+        .fn()
+        .mockResolvedValue([consumer]);
+      const post = jest.fn().mockResolvedValue({ status: 200 });
+      (service as any).httpClient = { post };
+      const event = makeEvent();
+
+      await (service as any).deliverEventToConsumer(event, consumer, 1);
+      // Second call is a duplicate — must be skipped.
+      await (service as any).deliverEventToConsumer(event, consumer, 1);
+
+      expect(post).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Backend/src/stellar-monitor/services/webhook-delivery.service.ts
+++ b/Backend/src/stellar-monitor/services/webhook-delivery.service.ts
@@ -1,10 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { createHmac } from 'crypto';
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { WebhookConsumer } from '../entities/webhook-consumer.entity';
 import { StellarEvent } from '../entities/stellar-event.entity';
 import { ConsumerManagementService } from './consumer-management.service';
 import { EventStorageService } from './event-storage.service';
 import { DeliveryStatus, EventType } from '../types/stellar.types';
+import { validateWebhookUrl } from '../utils/ssrf.util';
 
 interface DeliveryResult {
   success: boolean;
@@ -13,15 +15,31 @@ interface DeliveryResult {
   responseTime?: number;
 }
 
+interface QueueItem {
+  event: StellarEvent;
+  consumer: WebhookConsumer;
+  attempt: number; // 1-based attempt counter
+}
+
 @Injectable()
 export class WebhookDeliveryService {
   private readonly logger = new Logger(WebhookDeliveryService.name);
   private readonly httpClient: AxiosInstance;
-  private readonly deliveryQueue: Array<{
-    event: StellarEvent;
-    consumer: WebhookConsumer;
-  }> = [];
+  private readonly deliveryQueue: QueueItem[] = [];
   private isProcessingQueue = false;
+
+  /** Exponential backoff schedule between attempts: 1s, 5s, 30s, 5m, 30m. */
+  static readonly RETRY_DELAYS_MS = [1000, 5000, 30000, 300000, 1800000];
+  /** Max delivery attempts before an event is moved to the dead-letter state. */
+  static readonly MAX_ATTEMPTS = 5;
+  /** Outbound HMAC signature header name. */
+  static readonly SIGNATURE_HEADER = 'X-Stellara-Signature';
+
+  // Keys (`${eventId}:${consumerId}`) already delivered — guarantees idempotency
+  // so a duplicate queue entry or retry can never double-deliver.
+  private readonly delivered = new Set<string>();
+  // Keys currently queued/in-flight — prevents queueing the same pair twice.
+  private readonly inFlight = new Set<string>();
 
   constructor(
     private readonly consumerManagementService: ConsumerManagementService,
@@ -39,6 +57,10 @@ export class WebhookDeliveryService {
     setInterval(() => this.processQueue(), 1000); // Process queue every second
   }
 
+  private deliveryKey(eventId: string, consumerId: string): string {
+    return `${eventId}:${consumerId}`;
+  }
+
   async queueEventForDelivery(event: StellarEvent): Promise<void> {
     const activeConsumers =
       await this.consumerManagementService.getActiveConsumers();
@@ -49,9 +71,17 @@ export class WebhookDeliveryService {
       return;
     }
 
-    // Add event to queue for each active consumer
+    // Add event to queue for each active consumer (deduplicated).
     for (const consumer of activeConsumers) {
-      this.deliveryQueue.push({ event, consumer });
+      const key = this.deliveryKey(event.id, consumer.id);
+      if (this.delivered.has(key) || this.inFlight.has(key)) {
+        this.logger.debug(
+          `Skipping duplicate queue for event ${event.id} / consumer ${consumer.id}`,
+        );
+        continue;
+      }
+      this.inFlight.add(key);
+      this.deliveryQueue.push({ event, consumer, attempt: 1 });
       this.logger.debug(`Queued event ${event.id} for consumer ${consumer.id}`);
     }
 
@@ -77,8 +107,8 @@ export class WebhookDeliveryService {
       const batch = this.deliveryQueue.splice(0, batchSize);
 
       await Promise.all(
-        batch.map(async ({ event, consumer }) => {
-          await this.deliverEventToConsumer(event, consumer);
+        batch.map(async ({ event, consumer, attempt }) => {
+          await this.deliverEventToConsumer(event, consumer, attempt);
         }),
       );
     } catch (error) {
@@ -94,8 +124,18 @@ export class WebhookDeliveryService {
   private async deliverEventToConsumer(
     event: StellarEvent,
     consumer: WebhookConsumer,
+    attempt: number,
   ): Promise<void> {
     const startTime = Date.now();
+    const key = this.deliveryKey(event.id, consumer.id);
+
+    // Idempotency: never deliver the same event to the same consumer twice.
+    if (this.delivered.has(key)) {
+      this.logger.debug(
+        `Event ${event.id} already delivered to consumer ${consumer.id}, skipping`,
+      );
+      return;
+    }
 
     try {
       // Check if consumer is still active (might have been deactivated during queue processing)
@@ -105,26 +145,41 @@ export class WebhookDeliveryService {
         this.logger.debug(
           `Skipping delivery to inactive consumer ${consumer.id}`,
         );
+        this.inFlight.delete(key);
         return;
       }
 
-      const result = await this.attemptDelivery(event, freshConsumer);
+      // SSRF protection: validate the (possibly re-pointed) URL right before
+      // calling it. An unsafe URL is permanently undeliverable — dead-letter it
+      // immediately rather than retrying.
+      try {
+        await validateWebhookUrl(freshConsumer.url);
+      } catch (ssrfError) {
+        this.logger.warn(
+          `Refusing delivery to unsafe URL for consumer ${consumer.id}: ${ssrfError.message}`,
+        );
+        await this.moveToDeadLetter(event, consumer, attempt, ssrfError.message);
+        return;
+      }
+
+      const result = await this.attemptDelivery(event, freshConsumer, attempt);
 
       const responseTime = Date.now() - startTime;
 
       if (result.success) {
+        this.delivered.add(key);
+        this.inFlight.delete(key);
         this.logger.log(
           `Successfully delivered event ${event.id} to consumer ${consumer.id}`,
         );
         await this.handleSuccessfulDelivery(event, consumer, responseTime);
       } else {
         this.logger.warn(
-          `Failed to deliver event ${event.id} to consumer ${consumer.id}: ${result.errorMessage}`,
+          `Failed to deliver event ${event.id} to consumer ${consumer.id} (attempt ${attempt}): ${result.errorMessage}`,
         );
-        await this.handleFailedDelivery(event, consumer, result, responseTime);
+        await this.handleFailedDelivery(event, consumer, result, attempt);
       }
     } catch (error) {
-      const responseTime = Date.now() - startTime;
       this.logger.error(
         `Exception during delivery to consumer ${consumer.id}: ${error.message}`,
         error.stack,
@@ -136,7 +191,7 @@ export class WebhookDeliveryService {
           success: false,
           errorMessage: error.message,
         },
-        responseTime,
+        attempt,
       );
     }
   }
@@ -144,6 +199,7 @@ export class WebhookDeliveryService {
   private async attemptDelivery(
     event: StellarEvent,
     consumer: WebhookConsumer,
+    attempt: number,
   ): Promise<DeliveryResult> {
     const payload = {
       id: event.id,
@@ -156,33 +212,33 @@ export class WebhookDeliveryService {
       deliveredAt: new Date().toISOString(),
     };
 
+    const body = JSON.stringify(payload);
+
     const config: AxiosRequestConfig = {
       timeout: consumer.timeoutMs,
       headers: {
         'X-Stellar-Event-ID': event.id,
         'X-Stellar-Event-Type': event.eventType,
-        'X-Delivery-Attempt': (event.deliveryAttempts + 1).toString(),
+        'X-Delivery-Attempt': attempt.toString(),
+        // Idempotency key lets consumers dedupe on their side too.
+        'X-Idempotency-Key': this.deliveryKey(event.id, consumer.id),
       },
     };
 
-    // Add signature if consumer has a secret
+    // Add HMAC-SHA256 signature if consumer has a secret so the consumer can
+    // verify the payload originated from us and was not tampered with.
     if (consumer.secret) {
-      const signature = this.generateSignature(
-        JSON.stringify(payload),
-        consumer.secret,
-      );
       config.headers = {
         ...config.headers,
-        'X-Signature': signature,
+        [WebhookDeliveryService.SIGNATURE_HEADER]: this.generateSignature(
+          body,
+          consumer.secret,
+        ),
       };
     }
 
     try {
-      const response = await this.httpClient.post(
-        consumer.url,
-        payload,
-        config,
-      );
+      const response = await this.httpClient.post(consumer.url, body, config);
 
       return {
         success: true,
@@ -209,8 +265,13 @@ export class WebhookDeliveryService {
       consumer.id,
     );
 
-    // Update consumer stats
+    // Update consumer stats and reset the in-flight attempt counter.
     await this.consumerManagementService.updateDeliveryStats(consumer.id, true);
+    await this.consumerManagementService.recordDeliveryProgress(
+      consumer.id,
+      0,
+      null,
+    );
 
     // Mark event as processed if delivered to all consumers
     const activeConsumers =
@@ -226,58 +287,83 @@ export class WebhookDeliveryService {
     event: StellarEvent,
     consumer: WebhookConsumer,
     result: DeliveryResult,
-    responseTime: number,
+    attempt: number,
   ): Promise<void> {
-    // Update consumer stats
+    // Update consumer stats and record the attempt/error on the consumer.
     await this.consumerManagementService.updateDeliveryStats(
       consumer.id,
       false,
     );
+    await this.consumerManagementService.recordDeliveryProgress(
+      consumer.id,
+      attempt,
+      result.errorMessage ?? null,
+    );
 
-    const attemptNumber = event.deliveryAttempts + 1;
-
-    if (attemptNumber >= consumer.maxRetries) {
-      // Max retries reached - mark as failed
-      await this.eventStorageService.updateEventStatus(
-        event.id,
-        DeliveryStatus.FAILED,
-        consumer.id,
+    if (attempt >= WebhookDeliveryService.MAX_ATTEMPTS) {
+      // Max attempts reached — move to dead-letter.
+      await this.moveToDeadLetter(
+        event,
+        consumer,
+        attempt,
         result.errorMessage,
       );
-
-      this.logger.warn(
-        `Max retries reached for event ${event.id} to consumer ${consumer.id}`,
-      );
-    } else {
-      // Schedule retry with exponential backoff
-      const delay = this.calculateBackoffDelay(attemptNumber);
-      this.logger.debug(
-        `Scheduling retry ${attemptNumber}/${consumer.maxRetries} for event ${event.id} in ${delay}ms`,
-      );
-
-      setTimeout(() => {
-        this.deliveryQueue.push({ event, consumer });
-        if (!this.isProcessingQueue) {
-          this.processQueue();
-        }
-      }, delay);
+      return;
     }
+
+    // Schedule retry with exponential backoff.
+    const delay = this.calculateBackoffDelay(attempt);
+    this.logger.debug(
+      `Scheduling retry ${attempt + 1}/${WebhookDeliveryService.MAX_ATTEMPTS} for event ${event.id} in ${delay}ms`,
+    );
+
+    await this.eventStorageService.updateEventStatus(
+      event.id,
+      DeliveryStatus.RETRYING,
+      consumer.id,
+      result.errorMessage,
+    );
+
+    setTimeout(() => {
+      this.deliveryQueue.push({ event, consumer, attempt: attempt + 1 });
+      if (!this.isProcessingQueue) {
+        this.processQueue();
+      }
+    }, delay);
   }
 
+  private async moveToDeadLetter(
+    event: StellarEvent,
+    consumer: WebhookConsumer,
+    attempt: number,
+    errorMessage?: string,
+  ): Promise<void> {
+    this.inFlight.delete(this.deliveryKey(event.id, consumer.id));
+
+    await this.eventStorageService.updateEventStatus(
+      event.id,
+      DeliveryStatus.DEAD_LETTER,
+      consumer.id,
+      errorMessage,
+    );
+
+    this.logger.error(
+      `Event ${event.id} moved to dead-letter for consumer ${consumer.id} after ${attempt} attempt(s): ${errorMessage ?? 'unknown error'}`,
+    );
+  }
+
+  /**
+   * Returns the backoff delay (ms) to wait before the next attempt.
+   * `attempt` is the 1-based number of the attempt that just failed.
+   */
   private calculateBackoffDelay(attempt: number): number {
-    // Exponential backoff: 1s, 2s, 4s, 8s, 16s, etc.
-    const baseDelay = 1000; // 1 second
-    const maxDelay = 300000; // 5 minutes max
-    return Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay);
+    const delays = WebhookDeliveryService.RETRY_DELAYS_MS;
+    const index = Math.min(attempt - 1, delays.length - 1);
+    return delays[index];
   }
 
   private generateSignature(payload: string, secret: string): string {
-    // In production, use proper HMAC signing
-    // This is a simplified example
-    return require('crypto')
-      .createHmac('sha256', secret)
-      .update(payload)
-      .digest('hex');
+    return createHmac('sha256', secret).update(payload).digest('hex');
   }
 
   async deliverTestEvent(consumerId: string): Promise<DeliveryResult> {
@@ -288,6 +374,16 @@ export class WebhookDeliveryService {
       return {
         success: false,
         errorMessage: 'Consumer is not active',
+      };
+    }
+
+    // Validate the URL before sending a test event too.
+    try {
+      await validateWebhookUrl(consumer.url);
+    } catch (error) {
+      return {
+        success: false,
+        errorMessage: error.message,
       };
     }
 
@@ -304,7 +400,7 @@ export class WebhookDeliveryService {
       },
     };
 
-    return this.attemptDelivery(testEvent as StellarEvent, consumer);
+    return this.attemptDelivery(testEvent as StellarEvent, consumer, 1);
   }
 
   getQueueSize(): number {

--- a/Backend/src/stellar-monitor/types/stellar.types.ts
+++ b/Backend/src/stellar-monitor/types/stellar.types.ts
@@ -11,6 +11,7 @@ export enum DeliveryStatus {
   DELIVERED = 'delivered',
   FAILED = 'failed',
   RETRYING = 'retrying',
+  DEAD_LETTER = 'dead_letter',
 }
 
 export enum ConsumerStatus {

--- a/Backend/src/stellar-monitor/utils/ssrf.util.ts
+++ b/Backend/src/stellar-monitor/utils/ssrf.util.ts
@@ -1,0 +1,134 @@
+import { isIP } from 'net';
+import { lookup } from 'dns/promises';
+
+/**
+ * SSRF protection helpers for outbound webhook URLs.
+ *
+ * Consumer-supplied URLs are attacker-controlled. Without validation a consumer
+ * could point a webhook at an internal service (cloud metadata endpoint, an
+ * internal admin API, etc.) and have our server make the request on its behalf.
+ * We therefore reject any URL that resolves to a private, loopback, link-local
+ * or otherwise reserved address.
+ */
+
+/** Hostnames that always map to the local machine. */
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'ip6-localhost', 'ip6-loopback']);
+
+/**
+ * Returns true if the given IP literal (v4 or v6) is private, loopback,
+ * link-local, or otherwise non-routable on the public internet.
+ */
+export function isPrivateIp(ip: string): boolean {
+  const version = isIP(ip);
+  if (version === 4) {
+    return isPrivateIpv4(ip);
+  }
+  if (version === 6) {
+    return isPrivateIpv6(ip);
+  }
+  // Not a valid IP literal — caller must resolve it first.
+  return false;
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((p) => parseInt(p, 10));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)) {
+    return true; // malformed — treat as unsafe
+  }
+  const [a, b] = parts;
+
+  // 0.0.0.0/8 — "this" network
+  if (a === 0) return true;
+  // 10.0.0.0/8 — private
+  if (a === 10) return true;
+  // 100.64.0.0/10 — carrier-grade NAT
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 127.0.0.0/8 — loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 — link-local (incl. cloud metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12 — private
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.0.0.0/24 & 192.0.2.0/24 — IETF/TEST-NET-1
+  if (a === 192 && b === 0) return true;
+  // 192.168.0.0/16 — private
+  if (a === 192 && b === 168) return true;
+  // 198.18.0.0/15 — benchmarking
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 224.0.0.0/4 multicast and 240.0.0.0/4 reserved
+  if (a >= 224) return true;
+
+  return false;
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const addr = ip.toLowerCase().split('%')[0]; // strip zone id
+
+  // Loopback ::1 and unspecified ::
+  if (addr === '::1' || addr === '::') return true;
+  // Unique local fc00::/7
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true;
+  // Link-local fe80::/10
+  if (addr.startsWith('fe8') || addr.startsWith('fe9') || addr.startsWith('fea') || addr.startsWith('feb')) {
+    return true;
+  }
+  // IPv4-mapped ::ffff:a.b.c.d — re-check embedded v4
+  const mapped = addr.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) {
+    return isPrivateIpv4(mapped[1]);
+  }
+
+  return false;
+}
+
+/**
+ * Validates that a webhook URL is safe to call. Throws an Error with a
+ * descriptive message when the URL is malformed, uses a non-HTTP(S) scheme,
+ * or resolves to a private/internal address.
+ *
+ * Resolves the hostname via DNS to defend against DNS-rebinding where a public
+ * name points at a private IP.
+ */
+export async function validateWebhookUrl(rawUrl: string): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid webhook URL: ${rawUrl}`);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Unsupported webhook URL scheme: ${url.protocol}`);
+  }
+
+  // Strip brackets from IPv6 literals (e.g. [::1]).
+  const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(hostname) || hostname.endsWith('.localhost')) {
+    throw new Error(`Webhook URL points to a blocked host: ${hostname}`);
+  }
+
+  // IP literal — check directly without DNS.
+  if (isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error(`Webhook URL resolves to a private address: ${hostname}`);
+    }
+    return;
+  }
+
+  // Hostname — resolve every address and reject if any is private.
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(hostname, { all: true });
+  } catch {
+    throw new Error(`Unable to resolve webhook host: ${hostname}`);
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new Error(
+        `Webhook URL resolves to a private address: ${address} (${hostname})`,
+      );
+    }
+  }
+}

--- a/Backend/src/stellar-monitor/validators/is-safe-webhook-url.validator.ts
+++ b/Backend/src/stellar-monitor/validators/is-safe-webhook-url.validator.ts
@@ -1,0 +1,55 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { isIP } from 'net';
+import { isPrivateIp } from '../utils/ssrf.util';
+
+/**
+ * Synchronous, IP-literal-level SSRF guard for DTO validation.
+ *
+ * This gives fast feedback at the API boundary by rejecting obvious offenders
+ * (localhost, private IP literals, non-HTTP schemes). Full DNS-resolution
+ * checks happen at delivery time via {@link validateWebhookUrl}, since DNS is
+ * async and can change between registration and delivery (rebinding).
+ */
+@ValidatorConstraint({ name: 'isSafeWebhookUrl', async: false })
+export class IsSafeWebhookUrlConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return false;
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+    const hostname = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) return false;
+
+    if (isIP(hostname) && isPrivateIp(hostname)) return false;
+
+    return true;
+  }
+
+  defaultMessage(): string {
+    return 'url must be a public http(s) URL and must not point to a private or internal address';
+  }
+}
+
+export function IsSafeWebhookUrl(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsSafeWebhookUrlConstraint,
+    });
+  };
+}


### PR DESCRIPTION
Closes #759

## What this does

The webhook delivery service used to queue events and send them out, but it had no real protection around it. This PR hardens the whole delivery path in the `stellar-monitor` module.

Here's what changed, point by point against the issue:

### 1. SSRF protection
Consumer webhook URLs are user-supplied, so someone could point one at an internal address (like the cloud metadata endpoint `169.254.169.254`) and make our server fetch it for them. Now every URL is checked before we call it.

- Rejects private/internal ranges: `127.x`, `10.x`, `192.168.x`, `169.254.x`, `172.16–31.x`, plus CGNAT and IPv6 loopback/ULA/link-local.
- For normal hostnames, it resolves DNS first and checks every resolved IP — so a public domain secretly pointing at a private IP (DNS rebinding) is also blocked.
- Checked both at delivery time and when a consumer registers.

### 2. HMAC signature
Every outbound payload now carries an `X-Stellara-Signature` header — an HMAC-SHA256 of the exact request body, signed with the consumer's own secret. Consumers can use it to confirm the payload really came from us and wasn't tampered with.

### 3. Backoff retry + dead-letter
Failed deliveries now retry on a fixed schedule — **1s, 5s, 30s, 5m, 30m** — up to 5 attempts. After that the event moves to a new `DEAD_LETTER` status instead of being retried forever.

> This also fixes a real bug in the old code: retries re-queued the event with a stale attempt counter, so it never actually escalated and could loop indefinitely.

### 4. New entity columns
Added `deliveryAttempts` and `lastError` to `WebhookConsumer` so we can see how many tries the current event has had and what last went wrong. Includes a migration.

### 5. DTO validation
Consumer registration now validates the URL with a `@IsSafeWebhookUrl` class-validator decorator, so bad URLs get rejected at the API boundary with a clear message.

### 6. Tests
New unit tests cover SSRF rejection, signature generation, retry escalation, and dead-letter. 34 cases, all green.

## Extra things i did (beyond the issue)

- **Idempotent delivery / dedup** — tracks delivered and in-flight `(event, consumer)` pairs and adds an `X-Idempotency-Key` header, so the same event can never be delivered twice even if it gets re-queued.
- **`DeliveryStatus.DEAD_LETTER`** — added a proper status value so dead-lettered events are queryable, not just "failed".
- **SSRF check on the test-event endpoint too** — the "send test webhook" path validates the URL as well, not just real deliveries.
- **DB migration** — `1784000000000-AddWebhookConsumerDeliveryColumns.ts` for the two new columns, idempotent with a working `down()`.
- **Fixed a pre-existing broken test** — `getAllConsumers` had a stale mock (it mocked `find` but the code uses a query builder); updated it so the suite is fully green.

## How to run

```bash
cd Backend
npm install
npx jest src/stellar-monitor       # all delivery + consumer tests
npm run migration:run              # apply the new columns

Notes

- package-lock.json was left out of this PR (only changed f no intentional dependency change).