### PR TITLE
feat: expand health checks into readiness and dependency-based status (#849)

### DIFF
--- a/Backend/src/health/auth-health.indicator.ts
+++ b/Backend/src/health/auth-health.indicator.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+export interface AuthHealthCheckResult {
+  status: 'ok' | 'error';
+  message?: string;
+  responseTimeMs?: number;
+}
+
+@Injectable()
+export class AuthHealthIndicator {
+  private readonly logger = new Logger(AuthHealthIndicator.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async isHealthy(): Promise<AuthHealthCheckResult> {
+    const start = Date.now();
+    try {
+      const secret = this.configService.get<string>('JWT_SECRET');
+      if (!secret) {
+        return {
+          status: 'error',
+          message: 'JWT_SECRET not configured',
+          responseTimeMs: Date.now() - start,
+        };
+      }
+
+      const testPayload = { sub: '__health_check__', iat: Math.floor(Date.now() / 1000) };
+      const token = this.jwtService.sign(testPayload, { expiresIn: '1s' });
+      this.jwtService.verify(token);
+
+      return {
+        status: 'ok',
+        responseTimeMs: Date.now() - start,
+      };
+    } catch (err: any) {
+      this.logger.warn(`Auth health check failed: ${err.message}`);
+      return {
+        status: 'error',
+        message: err.message,
+        responseTimeMs: Date.now() - start,
+      };
+    }
+  }
+}

--- a/Backend/src/health/database-health.indicator.ts
+++ b/Backend/src/health/database-health.indicator.ts
@@ -1,19 +1,30 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 
+export interface DatabaseHealthCheckResult {
+  status: 'ok' | 'error';
+  message?: string;
+  responseTimeMs?: number;
+}
+
 @Injectable()
 export class DatabaseHealthIndicator {
   private readonly logger = new Logger(DatabaseHealthIndicator.name);
 
   constructor(private readonly dataSource: DataSource) {}
 
-  async isHealthy(): Promise<{ status: string; message?: string }> {
+  async isHealthy(): Promise<DatabaseHealthCheckResult> {
+    const start = Date.now();
     try {
       await this.dataSource.query('SELECT 1');
-      return { status: 'ok' };
+      return { status: 'ok', responseTimeMs: Date.now() - start };
     } catch (err: any) {
       this.logger.warn(`Database health check failed: ${err.message}`);
-      return { status: 'error', message: err.message };
+      return {
+        status: 'error',
+        message: err.message,
+        responseTimeMs: Date.now() - start,
+      };
     }
   }
 }

--- a/Backend/src/health/health.controller.ts
+++ b/Backend/src/health/health.controller.ts
@@ -4,46 +4,72 @@ import {
   Logger,
   ServiceUnavailableException,
 } from '@nestjs/common';
-import { DataSource } from 'typeorm';
-import { RedisService } from '../redis/redis.service';
-import { StellarEventMonitorService } from '../stellar-monitor/services/stellar-event-monitor.service';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { DatabaseHealthIndicator } from './database-health.indicator';
+import { RedisHealthIndicator } from './redis-health.indicator';
+import { QueueHealthIndicator, QueueHealthCheckResult } from './queue-health.indicator';
+import { AuthHealthIndicator } from './auth-health.indicator';
+import { StellarEventMonitorService } from '../stellar-monitor/services/stellar-event-monitor.service';
 
+@ApiTags('Health')
 @Controller('health')
 export class HealthController {
   private readonly logger = new Logger(HealthController.name);
 
   constructor(
     private readonly databaseHealthIndicator: DatabaseHealthIndicator,
-    private readonly redisService: RedisService,
+    private readonly redisHealthIndicator: RedisHealthIndicator,
+    private readonly queueHealthIndicator: QueueHealthIndicator,
+    private readonly authHealthIndicator: AuthHealthIndicator,
     private readonly stellarMonitorService: StellarEventMonitorService,
   ) {}
 
   @Get('live')
+  @ApiOperation({ summary: 'Liveness probe — confirms the process is running' })
+  @ApiResponse({ status: 200, description: 'Service is alive' })
   getLiveness() {
     return { status: 'ok', timestamp: new Date().toISOString() };
   }
 
   @Get('ready')
+  @ApiOperation({ summary: 'Readiness probe — checks all downstream dependencies' })
+  @ApiResponse({ status: 200, description: 'All dependencies healthy' })
+  @ApiResponse({ status: 503, description: 'One or more dependencies unhealthy' })
   async getReadiness() {
-    const checks: Record<string, { status: string; message?: string; [key: string]: any }> = {};
+    const start = Date.now();
+    const checks: Record<string, any> = {};
     let allHealthy = true;
 
+    // Database
     const databaseCheck = await this.databaseHealthIndicator.isHealthy();
     checks.database = databaseCheck;
     if (databaseCheck.status === 'error') {
       allHealthy = false;
     }
 
-    try {
-      await this.redisService.client.ping();
-      checks.redis = { status: 'ok' };
-    } catch (err: any) {
-      this.logger.warn(`Redis health check failed: ${err.message}`);
-      checks.redis = { status: 'error', message: err.message };
+    // Redis
+    const redisCheck = await this.redisHealthIndicator.isHealthy();
+    checks.redis = redisCheck;
+    if (redisCheck.status === 'error') {
       allHealthy = false;
     }
 
+    // Queue
+    const queueCheck: QueueHealthCheckResult =
+      await this.queueHealthIndicator.isHealthy();
+    checks.queue = queueCheck;
+    if (queueCheck.status === 'error') {
+      allHealthy = false;
+    }
+
+    // Auth
+    const authCheck = await this.authHealthIndicator.isHealthy();
+    checks.auth = authCheck;
+    if (authCheck.status === 'error') {
+      allHealthy = false;
+    }
+
+    // Stellar Monitor (existing)
     try {
       const monitorStatus = this.stellarMonitorService.getStatus();
       checks.stellarMonitor = {
@@ -60,6 +86,7 @@ export class HealthController {
     const response = {
       status: allHealthy ? 'ok' : 'error',
       timestamp: new Date().toISOString(),
+      responseTimeMs: Date.now() - start,
       checks,
     };
 

--- a/Backend/src/health/health.module.ts
+++ b/Backend/src/health/health.module.ts
@@ -1,12 +1,39 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { StellarMonitorModule } from '../stellar-monitor/stellar-monitor.module';
 import { HealthController } from './health.controller';
 import { DatabaseHealthIndicator } from './database-health.indicator';
+import { RedisHealthIndicator } from './redis-health.indicator';
+import { QueueHealthIndicator } from './queue-health.indicator';
+import { AuthHealthIndicator } from './auth-health.indicator';
 
 @Module({
-  imports: [StellarMonitorModule, TypeOrmModule.forFeature([])],
+  imports: [
+    StellarMonitorModule,
+    TypeOrmModule.forFeature([]),
+    BullModule.registerQueue(
+      { name: 'deploy-contract' },
+      { name: 'process-tts' },
+      { name: 'index-market-news' },
+    ),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+      }),
+      inject: [ConfigService],
+    }),
+    ConfigModule,
+  ],
   controllers: [HealthController],
-  providers: [DatabaseHealthIndicator],
+  providers: [
+    DatabaseHealthIndicator,
+    RedisHealthIndicator,
+    QueueHealthIndicator,
+    AuthHealthIndicator,
+  ],
 })
 export class HealthModule {}

--- a/Backend/src/health/queue-health.indicator.ts
+++ b/Backend/src/health/queue-health.indicator.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import type { Queue } from 'bull';
+
+export interface QueueHealthCheckResult {
+  status: 'ok' | 'error' | 'degraded';
+  message?: string;
+  responseTimeMs?: number;
+  queueCount?: number;
+  failedCount?: number;
+}
+
+@Injectable()
+export class QueueHealthIndicator {
+  private readonly logger = new Logger(QueueHealthIndicator.name);
+
+  constructor(
+    @InjectQueue('deploy-contract')
+    private readonly deployContractQueue: Queue,
+    @InjectQueue('process-tts')
+    private readonly processTtsQueue: Queue,
+    @InjectQueue('index-market-news')
+    private readonly indexMarketNewsQueue: Queue,
+  ) {}
+
+  async isHealthy(): Promise<QueueHealthCheckResult> {
+    const start = Date.now();
+    try {
+      const queues = [
+        this.deployContractQueue,
+        this.processTtsQueue,
+        this.indexMarketNewsQueue,
+      ];
+
+      let totalWaiting = 0;
+      let totalFailed = 0;
+
+      for (const queue of queues) {
+        const [waiting, failed] = await Promise.all([
+          queue.getWaitingCount(),
+          queue.getFailedCount(),
+        ]);
+        totalWaiting += waiting;
+        totalFailed += failed;
+      }
+
+      const responseTimeMs = Date.now() - start;
+
+      if (totalFailed > 100) {
+        return {
+          status: 'degraded',
+          message: `${totalFailed} failed jobs across queues`,
+          responseTimeMs,
+          queueCount: queues.length,
+          failedCount: totalFailed,
+        };
+      }
+
+      return {
+        status: 'ok',
+        responseTimeMs,
+        queueCount: queues.length,
+        failedCount: totalFailed,
+      };
+    } catch (err: any) {
+      this.logger.warn(`Queue health check failed: ${err.message}`);
+      return {
+        status: 'error',
+        message: err.message,
+        responseTimeMs: Date.now() - start,
+      };
+    }
+  }
+}

--- a/Backend/src/health/redis-health.indicator.ts
+++ b/Backend/src/health/redis-health.indicator.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RedisService } from '../redis/redis.service';
+
+export interface HealthCheckResult {
+  status: 'ok' | 'error';
+  message?: string;
+  responseTimeMs?: number;
+}
+
+@Injectable()
+export class RedisHealthIndicator {
+  private readonly logger = new Logger(RedisHealthIndicator.name);
+
+  constructor(private readonly redisService: RedisService) {}
+
+  async isHealthy(): Promise<HealthCheckResult> {
+    const start = Date.now();
+    try {
+      await this.redisService.client.ping();
+      return {
+        status: 'ok',
+        responseTimeMs: Date.now() - start,
+      };
+    } catch (err: any) {
+      this.logger.warn(`Redis health check failed: ${err.message}`);
+      return {
+        status: 'error',
+        message: err.message,
+        responseTimeMs: Date.now() - start,
+      };
+    }
+  }
+}

--- a/Backend/test/health.e2e-spec.ts
+++ b/Backend/test/health.e2e-spec.ts
@@ -6,18 +6,28 @@ import { DataSource } from 'typeorm';
 import { RedisService } from '../src/redis/redis.service';
 import { StellarEventMonitorService } from '../src/stellar-monitor/services/stellar-event-monitor.service';
 import { HealthController } from '../src/health/health.controller';
+import { DatabaseHealthIndicator } from '../src/health/database-health.indicator';
+import { RedisHealthIndicator } from '../src/health/redis-health.indicator';
+import { QueueHealthIndicator } from '../src/health/queue-health.indicator';
+import { AuthHealthIndicator } from '../src/health/auth-health.indicator';
 
 describe('HealthModule (e2e)', () => {
   let app: INestApplication<App>;
 
-  const mockDataSource = {
-    query: jest.fn(),
+  const mockDatabaseHealthIndicator = {
+    isHealthy: jest.fn(),
   };
 
-  const mockRedisService = {
-    client: {
-      ping: jest.fn(),
-    },
+  const mockRedisHealthIndicator = {
+    isHealthy: jest.fn(),
+  };
+
+  const mockQueueHealthIndicator = {
+    isHealthy: jest.fn(),
+  };
+
+  const mockAuthHealthIndicator = {
+    isHealthy: jest.fn(),
   };
 
   const mockStellarMonitorService = {
@@ -28,8 +38,10 @@ describe('HealthModule (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
       providers: [
-        { provide: DataSource, useValue: mockDataSource },
-        { provide: RedisService, useValue: mockRedisService },
+        { provide: DatabaseHealthIndicator, useValue: mockDatabaseHealthIndicator },
+        { provide: RedisHealthIndicator, useValue: mockRedisHealthIndicator },
+        { provide: QueueHealthIndicator, useValue: mockQueueHealthIndicator },
+        { provide: AuthHealthIndicator, useValue: mockAuthHealthIndicator },
         {
           provide: StellarEventMonitorService,
           useValue: mockStellarMonitorService,
@@ -64,8 +76,24 @@ describe('HealthModule (e2e)', () => {
 
   describe('/health/ready (GET)', () => {
     it('should return 200 when all dependencies are healthy', async () => {
-      mockDataSource.query.mockResolvedValue([{ '1': 1 }]);
-      mockRedisService.client.ping.mockResolvedValue('PONG');
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 5,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 2,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
       mockStellarMonitorService.getStatus.mockReturnValue({
         isMonitoring: true,
         lastLedgerSequence: 12345,
@@ -78,8 +106,15 @@ describe('HealthModule (e2e)', () => {
 
       expect(res.body.status).toBe('ok');
       expect(res.body.timestamp).toBeDefined();
-      expect(res.body.checks.database).toEqual({ status: 'ok' });
-      expect(res.body.checks.redis).toEqual({ status: 'ok' });
+      expect(res.body.responseTimeMs).toBeDefined();
+      expect(res.body.checks.database).toMatchObject({ status: 'ok' });
+      expect(res.body.checks.redis).toMatchObject({ status: 'ok' });
+      expect(res.body.checks.queue).toMatchObject({
+        status: 'ok',
+        queueCount: 3,
+        failedCount: 0,
+      });
+      expect(res.body.checks.auth).toMatchObject({ status: 'ok' });
       expect(res.body.checks.stellarMonitor).toMatchObject({
         status: 'ok',
         isMonitoring: true,
@@ -88,8 +123,25 @@ describe('HealthModule (e2e)', () => {
     });
 
     it('should return 503 when database is down', async () => {
-      mockDataSource.query.mockRejectedValue(new Error('DB connection failed'));
-      mockRedisService.client.ping.mockResolvedValue('PONG');
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'DB connection failed',
+        responseTimeMs: 100,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 2,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
       mockStellarMonitorService.getStatus.mockReturnValue({
         isMonitoring: true,
         lastLedgerSequence: 12345,
@@ -107,10 +159,25 @@ describe('HealthModule (e2e)', () => {
     });
 
     it('should return 503 when redis is down', async () => {
-      mockDataSource.query.mockResolvedValue([{ '1': 1 }]);
-      mockRedisService.client.ping.mockRejectedValue(
-        new Error('Redis connection refused'),
-      );
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 5,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'Redis connection refused',
+        responseTimeMs: 100,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
       mockStellarMonitorService.getStatus.mockReturnValue({
         isMonitoring: true,
         lastLedgerSequence: 12345,
@@ -127,11 +194,95 @@ describe('HealthModule (e2e)', () => {
       expect(res.body.checks.redis.message).toBe('Redis connection refused');
     });
 
+    it('should return 503 when queue is down', async () => {
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 5,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 2,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'Bull connection refused',
+        responseTimeMs: 100,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
+      mockStellarMonitorService.getStatus.mockReturnValue({
+        isMonitoring: true,
+        lastLedgerSequence: 12345,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/health/ready')
+        .expect(503);
+
+      expect(res.body.status).toBe('error');
+      expect(res.body.checks.queue.status).toBe('error');
+      expect(res.body.checks.queue.message).toBe('Bull connection refused');
+    });
+
+    it('should return 503 when auth is down', async () => {
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 5,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 2,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'JWT_SECRET not configured',
+        responseTimeMs: 1,
+      });
+      mockStellarMonitorService.getStatus.mockReturnValue({
+        isMonitoring: true,
+        lastLedgerSequence: 12345,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/health/ready')
+        .expect(503);
+
+      expect(res.body.status).toBe('error');
+      expect(res.body.checks.auth.status).toBe('error');
+      expect(res.body.checks.auth.message).toBe('JWT_SECRET not configured');
+    });
+
     it('should return 503 when both database and redis are down', async () => {
-      mockDataSource.query.mockRejectedValue(new Error('DB timeout'));
-      mockRedisService.client.ping.mockRejectedValue(
-        new Error('Redis timeout'),
-      );
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'DB timeout',
+        responseTimeMs: 5000,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'Redis timeout',
+        responseTimeMs: 5000,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
       mockStellarMonitorService.getStatus.mockReturnValue({
         isMonitoring: true,
         lastLedgerSequence: 12345,
@@ -145,6 +296,81 @@ describe('HealthModule (e2e)', () => {
       expect(res.body.status).toBe('error');
       expect(res.body.checks.database.status).toBe('error');
       expect(res.body.checks.redis.status).toBe('error');
+    });
+
+    it('should return 503 when all dependencies are down', async () => {
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'DB timeout',
+        responseTimeMs: 5000,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'Redis timeout',
+        responseTimeMs: 5000,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'Queue timeout',
+        responseTimeMs: 5000,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'error',
+        message: 'JWT secret missing',
+        responseTimeMs: 0,
+      });
+      mockStellarMonitorService.getStatus.mockReturnValue({
+        isMonitoring: false,
+        lastLedgerSequence: undefined,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/health/ready')
+        .expect(503);
+
+      expect(res.body.status).toBe('error');
+      expect(res.body.checks.database.status).toBe('error');
+      expect(res.body.checks.redis.status).toBe('error');
+      expect(res.body.checks.queue.status).toBe('error');
+      expect(res.body.checks.auth.status).toBe('error');
+    });
+
+    it('should include responseTimeMs for each dependency check', async () => {
+      mockDatabaseHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 5,
+      });
+      mockRedisHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 2,
+      });
+      mockQueueHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 3,
+        queueCount: 3,
+        failedCount: 0,
+      });
+      mockAuthHealthIndicator.isHealthy.mockResolvedValue({
+        status: 'ok',
+        responseTimeMs: 1,
+      });
+      mockStellarMonitorService.getStatus.mockReturnValue({
+        isMonitoring: true,
+        lastLedgerSequence: 12345,
+        horizonUrl: 'https://horizon-testnet.stellar.org',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/health/ready')
+        .expect(200);
+
+      expect(res.body.responseTimeMs).toBeDefined();
+      expect(typeof res.body.responseTimeMs).toBe('number');
+      expect(res.body.checks.database.responseTimeMs).toBeDefined();
+      expect(res.body.checks.redis.responseTimeMs).toBeDefined();
+      expect(res.body.checks.queue.responseTimeMs).toBeDefined();
+      expect(res.body.checks.auth.responseTimeMs).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Replaces basic liveness endpoints with comprehensive readiness checks that verify DB, Redis, queue, and auth dependencies.

## Changes

- **New health indicators**: `redis-health.indicator.ts`, `queue-health.indicator.ts`, `auth-health.indicator.ts`
- **Enhanced readiness endpoint** (`GET /health/ready`): checks DB, Redis, Queue, Auth, and Stellar Monitor
- **Structured JSON responses**: per-dependency status, messages, and response times
- **Consistent `responseTimeMs`**: added to database health indicator for parity with other indicators
- **Updated `health.module.ts`**: registers all indicators with proper `BullModule` and `JwtModule` imports
- **Updated E2E tests**: covers all dependency checks including queue and auth failures

## Health Response Format

```json
{
  "status": "ok",
  "timestamp": "2026-07-20T...",
  "responseTimeMs": 42,
  "checks": {
    "database": { "status": "ok", "responseTimeMs": 5 },
    "redis": { "status": "ok", "responseTimeMs": 2 },
    "queue": { "status": "ok", "queueCount": 3, "failedCount": 0, "responseTimeMs": 3 },
    "auth": { "status": "ok", "responseTimeMs": 1 },
    "stellarMonitor": { "status": "ok", "isMonitoring": true }
  }
}
```

- **HTTP 200** = all dependencies healthy
- **HTTP 503** = one or more dependencies unhealthy

Closes #849
